### PR TITLE
Feat/#38: 공지사항 카드 컴포넌트 구현

### DIFF
--- a/src/components/Card/AnnounceCard/index.test.tsx
+++ b/src/components/Card/AnnounceCard/index.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import AnnounceCard from '.';
+
+describe('공지사항 카드 컴포넌트 테스트', () => {
+  const oldWindowLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      enumerable: true,
+      value: new URL(window.location.href),
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: false,
+      enumerable: true,
+      value: oldWindowLocation,
+    });
+  });
+
+  it('카드 클릭시 페이지 이동 테스트', async () => {
+    const data = {
+      title: '“아는 만큼 예뻐진다” 최신 CSS 기능 10가지',
+      path: 'https://www.itworld.co.kr/t/61023/%EA%B0%9C%EB%B0%9C%EC%9E%90/288031',
+      date: '2023-04-24',
+      desc: '1996년에 등장한 CSS(Cascading Style Sheets)는 여전히 웹 개발 스택의 필수적인 부분으로 계속 발전하고 있다. 활발하게 사용되는 모든 언어가 그렇듯 CSS도 실제 환경에 대응해 새로운 기능을 끊임없이 내놓고 있다. 이처럼 빠른 발전 속도로 인해 CSS를 주로 다루는 개발자조차 새로운 기능을 놓치기 쉽다. 올해 CSS에 도입되는 가장 유용한 새로운 기능에 대해 알아보자.',
+    };
+
+    render(<AnnounceCard {...data} />, { wrapper: MemoryRouter });
+
+    const card = screen.getByTestId('card');
+    await userEvent.click(card);
+    expect(window.location.href).toBe(data.path);
+  });
+});

--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -1,0 +1,68 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { THEME } from '@styles/ThemeProvider/theme';
+
+interface AnnounceCardProps {
+  title: string;
+  path: string;
+  date: string;
+  desc: string;
+}
+
+const AnnounceCard = ({ title, path, date, desc }: AnnounceCardProps) => {
+  const onClick = () => {
+    window.location.href = path;
+  };
+  return (
+    <Card onClick={onClick} data-testid="card">
+      <div
+        css={css`
+          display: flex;
+          align-items: center;
+        `}
+      >
+        <span>{title}</span>
+        <div
+          css={css`
+            border-left: 1px solid gray;
+            height: 12px;
+            margin: 0 10px;
+          `}
+        />
+        <span>{date}</span>
+      </div>
+      <p>{desc}</p>
+    </Card>
+  );
+};
+
+export default AnnounceCard;
+
+const Card = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding: 10px;
+  cursor: pointer;
+
+  color: ${THEME.TEXT.BLACK};
+
+  & > div > span:first-child {
+    font-size: 18px;
+    font-weight: bold;
+  }
+
+  & > div > span:nth-child(3) {
+    font-size: 12px;
+  }
+
+  & > p {
+    margin-top: 10px;
+    line-height: 25px;
+    overflow: hidden;
+    text-overflow: clip;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+`;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

* Closes : #38 
* 공지사항 카드 컴포넌트 구현 했어요.

## 💫 설명

<!--

- 현재 Pr 설명

-->

* 아직 크롤링을 통한 데이터를 가져올 수 있는 서버 측 로직이 없기 때문에 네이버 기사 하나 가져와서 구현했어요.
  * 앱 내부 url 이동이라면, `routerTo` 함수를 사용했겠지만 앱 외부 url 이동이기 때문에 `window.location.href` 를 사용 했어요.
* Figma 에서 두 줄만 내용이 채워져 있어서 내용이 최대 두줄 까지만 나오도록 했어요.
* 테스트 코드 작성 때, 했던 고민은 [여기](https://paper-mass-5ff.notion.site/4-30-e42ab08143814ed6bf39c9c0ee6d991c) 서 확인할 수 있어요.


## 📷 스크린샷 (Optional)

![스크린샷 2023-04-30 23 01 24](https://user-images.githubusercontent.com/68489467/235357459-7620c37e-0fab-417e-8003-fd0a3a10bee0.png)