### PR TITLE
Feat/#72: 마이페이지 구현

### DIFF
--- a/src/@types/styles/icon.ts
+++ b/src/@types/styles/icon.ts
@@ -6,4 +6,6 @@ export type IconKind =
   | 'notification'
   | 'menu'
   | 'arrowBack'
-  | 'plus';
+  | 'plus'
+  | 'edit'
+  | 'suggest';

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -9,6 +9,8 @@ import {
   MdMenu,
   MdArrowBackIos,
   MdAddCircleOutline,
+  MdOutlineModeEdit,
+  MdOutlineQuestionAnswer,
 } from 'react-icons/md';
 
 const ICON: { [key in IconKind]: IconType } = {
@@ -20,6 +22,8 @@ const ICON: { [key in IconKind]: IconType } = {
   menu: MdMenu,
   arrowBack: MdArrowBackIos,
   plus: MdAddCircleOutline,
+  edit: MdOutlineModeEdit,
+  suggest: MdOutlineQuestionAnswer,
 };
 
 interface IconProps {

--- a/src/components/Modal/MajorModal/index.tsx
+++ b/src/components/Modal/MajorModal/index.tsx
@@ -42,7 +42,7 @@ const ModalContent = styled.div`
   align-items: center;
 
   background-color: ${THEME.TEXT.WHITE};
-  padding: 50px;
+  padding: 30px;
   border-radius: 15px;
 
   Button {

--- a/src/components/Modal/SuggestionModal/index.tsx
+++ b/src/components/Modal/SuggestionModal/index.tsx
@@ -4,7 +4,7 @@ import { SERVER_URL } from '@config/index';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { THEME } from '@styles/ThemeProvider/theme';
-import { areaResize } from '@utils/styles/area-resize';
+import { areaResize } from '@utils/styles/textarea-resize';
 import React, { useRef, useState } from 'react';
 
 import Modal from '..';

--- a/src/components/Modal/SuggestionModal/index.tsx
+++ b/src/components/Modal/SuggestionModal/index.tsx
@@ -1,0 +1,95 @@
+import http from '@apis/http';
+import Button from '@components/Button';
+import { SERVER_URL } from '@config/index';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { areaResize } from '@utils/styles/area-resize';
+import React, { useRef, useState } from 'react';
+
+import Modal from '..';
+
+interface SuggestionModalProps {
+  onClose: () => void;
+}
+
+const SuggestionModal = ({ onClose }: SuggestionModalProps) => {
+  const areaRef = useRef<HTMLTextAreaElement>(null);
+  const [isEmtpy, setIsEmpty] = useState<boolean>(true);
+
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.currentTarget.value) setIsEmpty(false);
+    else setIsEmpty(true);
+  };
+  const onResize = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    areaResize(e.currentTarget);
+  };
+
+  const onSuggest = async () => {
+    await http.post(
+      `${SERVER_URL}/api/suggestion`,
+      {
+        content: areaRef.current?.value,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal onClose={onClose}>
+      <ModalContent>
+        <span
+          css={css`
+            color: ${THEME.TEXT.BLACK};
+            font-weight: bold;
+            margin-bottom: 15px;
+          `}
+        >
+          건의사항
+        </span>
+        <TextArea
+          placeholder="건의사항을 남겨주세요."
+          rows={1}
+          ref={areaRef}
+          onKeyDown={onResize}
+          onKeyUp={onResize}
+          onChange={onChange}
+        ></TextArea>
+        <Button onClick={onSuggest} disabled={isEmtpy}>
+          보내기
+        </Button>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default SuggestionModal;
+
+const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  background-color: ${THEME.TEXT.WHITE};
+  padding: 30px;
+  border-radius: 15px;
+`;
+
+const TextArea = styled.textarea`
+  line-height: 1.5;
+  padding: 10px;
+  resize: none;
+  overflow-y: hidden;
+
+  font-size: 16px;
+  font-weight: bold;
+  border-radius: 8px;
+
+  &::placeholder {
+    color: ${THEME.TEXT.GRAY};
+    font-weight: lighter;
+  }
+`;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -22,6 +22,7 @@ const Modal = ({ children, onClose }: ModalProps) => {
       <div
         css={css`
           animation: ${isOpen ? modalIn : modalOut} 0.3s ease-out;
+          width: 80%;
         `}
       >
         {children}

--- a/src/pages/My/index.test.tsx
+++ b/src/pages/My/index.test.tsx
@@ -1,0 +1,44 @@
+import MajorProvider from '@components/MajorProvider';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
+
+import My from '.';
+
+const mockRouterTo = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockRouterTo,
+}));
+
+describe('마이 페이지 동작 테스트', () => {
+  it('건의사항 남기기 버튼 클릭 시 모달 렌더링 테스트', async () => {
+    render(
+      <MajorProvider>
+        <My />
+      </MajorProvider>,
+      { wrapper: MemoryRouter },
+    );
+
+    const modalButton = screen.getByTestId('modal');
+    await act(async () => {
+      await userEvent.click(modalButton);
+    });
+
+    expect(screen.getByText('건의사항')).toBeInTheDocument();
+  });
+
+  it('전공수정 버튼 클릭 시 페이지 이동 테스트', async () => {
+    render(
+      <MajorProvider>
+        <My />
+      </MajorProvider>,
+      { wrapper: MemoryRouter },
+    );
+
+    const majorEditButton = screen.getByTestId('edit');
+    await userEvent.click(majorEditButton);
+    expect(mockRouterTo).toHaveBeenCalledWith('/major-decision');
+  });
+});

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -1,5 +1,82 @@
+import Button from '@components/Button';
+import Icon from '@components/Icon';
+import SuggestionModal from '@components/Modal/SuggestionModal';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import useMajor from '@hooks/useMajor';
+import useRoter from '@hooks/useRouter';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { useState } from 'react';
+
 const My = () => {
-  return <h1>마이 페이지</h1>;
+  const { major } = useMajor();
+  const { routerTo } = useRoter();
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const onClick = () => routerTo('/major-decision');
+
+  return (
+    <>
+      {isModalOpen && (
+        <SuggestionModal onClose={() => setIsModalOpen((prev) => !prev)} />
+      )}
+      <h1>마이페이지</h1>
+
+      <Major>
+        <span>전공</span>
+        <div
+          css={css`
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+          `}
+        >
+          <span>{major}</span>
+          <Icon
+            kind="edit"
+            onClick={onClick}
+            color={THEME.TEXT.GRAY}
+            data-testid="edit"
+          />
+        </div>
+      </Major>
+
+      <Suggestion>
+        <Button
+          onClick={() => setIsModalOpen((prev) => !prev)}
+          data-testid="modal"
+        >
+          <Icon kind="suggest" color={THEME.TEXT.WHITE} />
+          <span>건의사항 남기기</span>
+        </Button>
+      </Suggestion>
+    </>
+  );
 };
 
 export default My;
+
+const Major = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding: 15px;
+`;
+
+const Suggestion = styled.div`
+  position: fixed;
+  bottom: 100px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  width: 90%;
+
+  Button {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    & > svg {
+      margin-right: 15px;
+    }
+  }
+`;

--- a/src/utils/styles/textarea-resize.ts
+++ b/src/utils/styles/textarea-resize.ts
@@ -1,0 +1,5 @@
+export function areaResize(area: HTMLTextAreaElement) {
+  area.style.height = 'auto';
+  area.style.height = `${area.scrollHeight - 20}px`;
+  area.style.lineHeight = '1.5';
+}


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

* Closes: #72 
* 마이페이지를 구현 했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->

* 모달 창에서 padding 사이즈가 너무 큰 것 같아서 `50px -> 30px` 로 변경했어요, 
  * 모달 창과 같은 스타일 관련 이슈들은 배포 시점에 **모바일 환경을 고려한 디자인을 고민하는 시점**에 다시 얘기 해봐야할 것 같아요
  * 모달 창 2개의 사이즈를 통일 하는것이 좋다고 판단해 `width: 80%` 로 고정했어요.

* 건의사항 textarea 의 세로칸 증가에 대하여
  * 사용자가 설정해둔 textarea 의 가로 길이를 벗어나는 경우
  * 사용자가 줄바꿈을 강제로 하는 경우
  * 위의 2가지 경우에 대해서 textarea 의 세로칸을 1칸 증가 해줘야 했어요, 기본 textarea 는 이 기능이 자동으로 되지 않고 스크롤바를 통해서 세로로 이동할 수 있도록 하는 기능밖에 없어요
```typescript
export function areaResize(area: HTMLTextAreaElement) {
  area.style.height = 'auto';
  area.style.height = `${area.scrollHeight - 20}px`;
  area.style.lineHeight = '1.5';
}
```
  * 현재 textarea 의 스크롤 높이에 따라서 `height` 의 값을 계속 업데이트 해줘야 했어요

https://github.com/hwinkr/algorithm/assets/68489467/534b25f8-103d-4a40-95d8-facdc661b11b

* msw 를 사용해서 브라우저 환경에서 notion api 동작을 테스트 하는 건, 라이브러리가 필요하고 커밋이 너무 많을 것 같아서 따로 이슈를 파서 진행할게요!

## 📷 스크린샷 (Optional)

https://github.com/hwinkr/algorithm/assets/68489467/b1ad89ee-811b-4be6-8dfc-1e1eb0890acc