### PR TITLE
Feat/#76: Suspense 적용

### DIFF
--- a/src/apis/Suspense/fetch-announce-list.ts
+++ b/src/apis/Suspense/fetch-announce-list.ts
@@ -1,0 +1,15 @@
+import Major from '@type/major';
+import { AxiosResponse } from 'axios';
+
+import wrapPromise from './wrap-promise';
+import http from '../http';
+
+const fetchAnnounceList = <T>(major: Major) => {
+  const promise: Promise<AxiosResponse<T>> = http
+    .get(`/announcement?major=${major}`)
+    .then((res) => res.data);
+
+  return wrapPromise<T>(promise);
+};
+
+export default fetchAnnounceList;

--- a/src/apis/Suspense/wrap-promise.ts
+++ b/src/apis/Suspense/wrap-promise.ts
@@ -9,10 +9,8 @@ const wrapPromise = <T>(promise: Promise<AxiosResponse<T>>) => {
 
   const suspender = promise.then(
     (res: AxiosResponse<T>) => {
-      setTimeout(() => {
-        status = 'resolve';
-        response = res;
-      }, 3000);
+      status = 'resolve';
+      response = res;
     },
     (err: AxiosError) => {
       status = 'error';

--- a/src/apis/Suspense/wrap-promise.ts
+++ b/src/apis/Suspense/wrap-promise.ts
@@ -1,0 +1,37 @@
+import { AxiosError, AxiosResponse } from 'axios';
+
+type PromiseResult<T> = AxiosResponse<T> | AxiosError | null;
+type PromiseStatus = 'pending' | 'resolve' | 'error';
+
+const wrapPromise = <T>(promise: Promise<AxiosResponse<T>>) => {
+  let response: PromiseResult<T> = null;
+  let status: PromiseStatus = 'pending';
+
+  const suspender = promise.then(
+    (res: AxiosResponse<T>) => {
+      setTimeout(() => {
+        status = 'resolve';
+        response = res;
+      }, 3000);
+    },
+    (err: AxiosError) => {
+      status = 'error';
+      response = err;
+    },
+  );
+
+  return {
+    read: () => {
+      switch (status) {
+        case 'pending':
+          throw suspender;
+        case 'error':
+          return response;
+        default:
+          return response;
+      }
+    },
+  };
+};
+
+export default wrapPromise;

--- a/src/components/Card/AnnounceCard/AnnounceList/index.tsx
+++ b/src/components/Card/AnnounceCard/AnnounceList/index.tsx
@@ -1,31 +1,28 @@
-import http from '@apis/http';
 import { AnnounceItem } from '@type/announcement';
-import Major from '@type/major';
-import { useEffect, useState } from 'react';
+import { AxiosError, AxiosResponse } from 'axios';
 
 import AnnounceCard from '..';
 
+type Resource = AxiosResponse<AnnounceItem[]> | AxiosError | null;
+
 interface AnnounceListProps {
-  major: Major;
+  resource: {
+    read: () => Resource;
+  };
 }
 
-const AnnounceList = ({ major }: AnnounceListProps) => {
-  const [announceList, setAnnounceList] = useState<AnnounceItem[] | null>(null);
-
-  useEffect(() => {
-    (async () => {
-      const axiosResult = await http.get(`/announcement?major=${major}`);
-      setAnnounceList(axiosResult.data);
-    })();
-  }, []);
+const AnnounceList = ({ resource }: AnnounceListProps) => {
+  const announceList: Resource = resource.read();
 
   return (
     <>
-      {announceList?.map((announce, idx) => (
-        <div key={idx}>
-          <AnnounceCard {...announce} />
-        </div>
-      ))}
+      {Array.isArray(announceList)
+        ? announceList.map((announce, idx) => (
+            <div key={idx}>
+              <AnnounceCard {...announce} />
+            </div>
+          ))
+        : null}
     </>
   );
 };

--- a/src/components/Card/AnnounceCard/Skeleton.tsx
+++ b/src/components/Card/AnnounceCard/Skeleton.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import SkeletomItem from '@styles/SkeletonItem';
+import SkeletomItem from '@styles/Skeleton/SkeletonItem';
 
 interface AnnounceCardSkeletonProps {
   length: number;

--- a/src/components/Card/AnnounceCard/Skeleton.tsx
+++ b/src/components/Card/AnnounceCard/Skeleton.tsx
@@ -1,0 +1,49 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import SkeletomItem from '@styles/SkeletonItem';
+
+interface AnnounceCardSkeletonProps {
+  length: number;
+}
+
+const AnnounceCardSkeleton = ({ length }: AnnounceCardSkeletonProps) => {
+  return (
+    <>
+      {Array.from({ length }, (_, idx) => (
+        <div key={idx}>
+          <Wrapper>
+            <Title></Title>
+            <div
+              css={css`
+                border-left: 1px solid gray;
+                height: 12px;
+                margin: 0 10px;
+              `}
+            />
+            <Date></Date>
+          </Wrapper>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default AnnounceCardSkeleton;
+
+const Wrapper = styled.div`
+  display: flex;
+  padding: 10px;
+  align-items: center;
+`;
+
+const Title = styled(SkeletomItem)`
+  flex: 9;
+  width: 100%;
+  height: 30px;
+`;
+
+const Date = styled(SkeletomItem)`
+  flex: 1;
+  width: 100%;
+  height: 20px;
+`;

--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -43,19 +43,13 @@ const Card = styled.div`
   & > div > span:first-of-type {
     font-size: 18px;
     font-weight: bold;
+    flex: 9;
+    text-align: center;
   }
 
   & > div > span:nth-of-type(2) {
     font-size: 12px;
-  }
-
-  & > p {
-    margin-top: 10px;
-    line-height: 25px;
-    overflow: hidden;
-    text-overflow: clip;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
+    flex: 1;
+    text-align: center;
   }
 `;

--- a/src/styles/Skeleton/SkeletonItem.ts
+++ b/src/styles/Skeleton/SkeletonItem.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+
+const SkeletomItem = styled.div`
+  width: 100%;
+  height: 30px;
+  background-color: #f2f2f2;
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+
+  @keyframes skeleton-gradient {
+    0% {
+      background-color: rgba(165, 165, 165, 0.1);
+    }
+    50% {
+      background-color: rgba(165, 165, 165, 0.3);
+    }
+    100% {
+      background-color: rgba(165, 165, 165, 0.1);
+    }
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    animation: skeleton-gradient 1.5s infinite ease-in-out;
+  }
+`;
+
+export default SkeletomItem;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
* Closes: #76 
* Suspense + Skeleton UI 를 구현했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->
* 자세한 구현방법, 구현을 위해 했던 고민들은 `부림이 기술 블로그` 에 작성 해놓을게요.(아직 작성 안함..ㅎ)
## 📌 사용방법
```typescript
const AnnounceList = lazy(
  () => import('@components/Card/AnnounceCard/AnnounceList'),
);

const Announcement = () => {
  const { major } = useMajor();
  return (
    <>
      <Suspense fallback={<AnnounceCardSkeleton length={3} />}>
        <AnnounceList resource={fetchAnnounceList(major)} />
      </Suspense>
    </>
  );
};
```
* `<AnnounceCardSkeleton length={3} />` 에서, `length={3}` 을 통해 몇개의 Skeleton UI 를 렌더링 할 것인지 미리 알 수 있도록 해줘야 해요.
* Skeleton UI 를 적용할 컴포넌트를 Suspense 의 자식 컴포넌트로 지정해주면 돼요!
* 자식 컴포넌트 내부에서는 Suspense 가 비동기 요청 프로미스의 현재 상태를 알 수 있도록 해줘야 해요(**주로 read 함수를 통해 구현**)
```typescript
const AnnounceList = ({ resource }: AnnounceListProps) => {
  const announceList: Resource = resource.read();
//...
```
## ✅ 왜 몇개의 Skeleton 을 렌더링 할 것인지 미리 알고 있어야 하는지?
```typescript
announceList.map((announce, idx) => (
    <Suspense fallback={<AnnounceCardSkeleton />}>
        <div key={idx}>
	    <AnnounceCard {...announce} />
	</div>
    </Suspense>
))
```
* Suspense 가 감싸고 있는 자식 컴포넌트 내부에서 비동기 요청이 이루어저야 `fallback` 에 설정해놓은 컴포넌트를 렌더링 할 수 있는데, 이 경우에서는 **이미 받아온 비동기 데이터** 를 통해서 렌더링을 하기 때문에, map 내부에 있는 컴포넌트 하나당 하나의 서스펜스를 적용할 수 가 없었어요.  즉, 저희는 한번에 하나의 데이터를 받아오는 것이 아니라, 배열 자료구조를 가지는 데이터를 한번에 받아오기 때문이에요.

## 📷 스크린샷 (Optional)
https://github.com/hwinkr/algorithm/assets/68489467/932122c6-136b-498d-9615-57322a25f308


