### PR TITLE
Config/#82: nginx 구성

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: dockerfile.prod
+    ports:
+      - '5173:5173'
+
+  nginx:
+    restart: always
+    build:
+      dockerfile: dockerfile
+      context: ./nginx/proxy
+    ports:
+      - '80:80'
+    links:
+      - frontend

--- a/dockerfile.prod
+++ b/dockerfile.prod
@@ -1,0 +1,12 @@
+FROM node:16 as builder
+WORKDIR /usr/src/app
+COPY package.json ./
+RUN yarn
+COPY ./ ./
+RUN pwd
+RUN yarn build
+
+FROM nginx
+EXPOSE 5173
+COPY ./nginx/static/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /usr/src/app/dist /usr/share/nginx/html

--- a/nginx/proxy/default.conf
+++ b/nginx/proxy/default.conf
@@ -1,0 +1,30 @@
+upstream frontend {
+    server frontend:5173;
+}
+
+upstream backend {
+    server frontend:5000;
+}
+
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://frontend;
+    }
+
+    location /api {
+        proxy_pass http://backend;
+    }
+}
+
+server {
+    listen 5173;
+
+    location /sockjs-node {
+        proxy_pass http://frontend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+}

--- a/nginx/proxy/dockerfile
+++ b/nginx/proxy/dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY ./default.conf /etc/nginx/conf.d/default.conf

--- a/nginx/static/default.conf
+++ b/nginx/static/default.conf
@@ -1,0 +1,13 @@
+server {
+    listen 5173;
+
+    location / {
+
+        root /usr/share/nginx/html;
+
+        index index.html index.htm;
+
+        try_files $uri  $uri/ /index.html;
+
+    }
+}


### PR DESCRIPTION
## 🤠 개요
- closes: #82 
- nginx 를 프록시와 정적 파일 제공하는 기능을 하나로 구성하려 했는데 구성에 어려움이 있어서 따로 구성했어요
- dockerfile 과 docker-compose 파일의 경우 개발환경과 배포환경을 따로 구성했어요 !
- 그리고 백엔드 URL 이 없기에 프론트엔드 URL 로 설정해뒀어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 도커파일 실행방법
- 기존 개발환경은 그대로 `docker-compose up` 하면은 간단하게 동작할 수 있어요
- 배포 환경에서는 `docker-compose -f docker-compose.prod.yml up` 을 이용해서 실행해야 해요 (파일 이름을 명시해줘야해요)

### 배포 환경에서 생기는 문제
- 배포환경을 실행해보면 에러가날 수 있어요. 그 이유는 내 파일을 그대로 도커 컨테이너에 복사하여 실행하는데 이때 node_modules 에 문제가 있어요
- 그 이유는 node_modules 는 package.json, yarn-lock.json 을 보고 내 환경에 맞게 모듈들을 설치하는데 내 로컬에 맞는 node_modules 를 도커 컨테이너로 복사해가서 사용하기에 에러가 발생해요
- 간단하게 local 에 있는 node_modules 를 삭제하고 도커 컴포즈를 실행하면 돼요

## 흐름 설명
1. 일단 클라이언트가 우리 앱(URL)에 접속해요 (http://localhost:5173)
2. 그러면 바로 우리 서버를 만나는게 아니라 프록시(nginx) 를 만나게 돼요. 그럼 프록시는 pathname 을 보고 /api 로 시작하면 백엔드 주소로 보내고 그게 아니라면 클라이언트로 보내게 돼요
3. 클라이언트로 보내게 된다면 클라이언트에 있는 정적 파일 제공자(nginx) 가 파일을 제공해줘요

## 추가 사항
- 프론트앤드 URL 에 pathname 을 /api 로 시작해도 백엔드주소로 요청이 가요
- 이는 나중에 한번 고려해보는게 좋을거 같아요. 바로 서버로 요청을 가는것보다 프록시를 한번 거쳐가는게 좋아요
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
- 정상적으로 동작함을 확인할 수 있어요 (테스트는 UI 를 위해 #80 을 잠시 머지해서 진행했어요)
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/552f59e7-6589-459d-9a1e-230756c038cf)

- 그리고 nginx 서버인 80번 포트로 접속해도 정상적으로 UI 가 나오는것을 확인할 수 있어요
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/dcbab9a9-625c-4119-a6ad-65cf15e5f78f)
