### PR TITLE
Refactor/#86: 배포된 백엔드와 통신되도록 엔드포인트 변경

### DIFF
--- a/src/apis/Suspense/fetch-announce-list.ts
+++ b/src/apis/Suspense/fetch-announce-list.ts
@@ -6,7 +6,7 @@ import http from '../http';
 
 const fetchAnnounceList = <T>(major: Major) => {
   const promise: Promise<AxiosResponse<T>> = http
-    .get(`/announcement?major=${major}`)
+    .get(`/api/announcement?major=${major}`)
     .then((res) => res.data);
 
   return wrapPromise<T>(promise);

--- a/src/components/Card/AnnounceCard/index.test.tsx
+++ b/src/components/Card/AnnounceCard/index.test.tsx
@@ -27,7 +27,7 @@ describe('공지사항 카드 컴포넌트 테스트', () => {
 
   it('카드 클릭시 페이지 이동 테스트', async () => {
     const axiosResult = await http.get(
-      '/announcement?major=컴퓨터인공지능학부',
+      '/api/announcement?major=컴퓨터인공지능학부',
     );
     const announceList: AnnounceItem[] = axiosResult.data;
 

--- a/src/components/List/CollegeList/index.tsx
+++ b/src/components/List/CollegeList/index.tsx
@@ -13,7 +13,7 @@ const CollegeList = () => {
   }, []);
 
   const fetchData = async () => {
-    const result = await http.get('/majorDecision');
+    const result = await http.get('/api/majorDecision');
     setCollegeList(result.data);
   };
 

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -16,7 +16,7 @@ const DepartmentList = () => {
   const { college } = useParams();
 
   const fetchData = async () => {
-    const result = await http.get(`majorDecision/${college}`);
+    const result = await http.get(`/api/majorDecision/${college}`);
     if (result.data === undefined) {
       router(-1);
     }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
-let SERVER_URL: string = import.meta.env.VITE_BACKEND_URL;
+let SERVER_URL = '13.209.91.5:8080';
 if (process.env.NODE_ENV === 'development') {
   SERVER_URL = 'http://localhost:8080';
 }

--- a/src/mocks/handlers/announceHandlers.ts
+++ b/src/mocks/handlers/announceHandlers.ts
@@ -2,7 +2,7 @@ import { SERVER_URL } from '@config/index';
 import { RequestHandler, rest } from 'msw';
 
 export const announceHandlers: RequestHandler[] = [
-  rest.get(`${SERVER_URL}/announcement`, (req, res, ctx) => {
+  rest.get(`${SERVER_URL}/api/announcement`, (req, res, ctx) => {
     const query = req.url.searchParams;
     if (query.get('major') === '컴퓨터인공지능학부') {
       return res(

--- a/src/mocks/handlers/majorHandlers.ts
+++ b/src/mocks/handlers/majorHandlers.ts
@@ -2,11 +2,11 @@ import { SERVER_URL } from '@config/index';
 import { rest, RequestHandler } from 'msw';
 
 export const majorHandlers: RequestHandler[] = [
-  rest.get(SERVER_URL + '/majorDecision', (req, res, ctx) => {
+  rest.get(SERVER_URL + '/api/majorDecision', (req, res, ctx) => {
     const collegeList = ['경영대학', '공과대학', '정보융합대학'];
     return res(ctx.status(200), ctx.json(collegeList));
   }),
-  rest.get(SERVER_URL + '/majorDecision/:college', (req, res, ctx) => {
+  rest.get(SERVER_URL + '/api/majorDecision/:college', (req, res, ctx) => {
     const { college } = req.params;
     if (college === '정보융합대학') {
       const INFORMATIONCONVERGENCE = [


### PR DESCRIPTION
## 🤠 개요

- config 파일에서 백엔드 주소를 직접 적어줬어요. (.env 파일에서 값을 가져오게 설정하려면 추가적으로 고려해야해요)
- 모든 api 요청 주소를 /api 로 시작하도록 변경했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
