### PR TITLE
Chore/#99: 백엔드 공지사항 데이터와 스키마 통일

### DIFF
--- a/src/@types/announcement.ts
+++ b/src/@types/announcement.ts
@@ -1,5 +1,9 @@
 export interface AnnounceItem {
+  id: number;
+  major: string;
   title: string;
-  path: string;
-  date: string;
+  link: string;
+  content: string;
+  uploadDate: string;
+  graduate: string | null;
 }

--- a/src/components/Card/AnnounceCard/index.test.tsx
+++ b/src/components/Card/AnnounceCard/index.test.tsx
@@ -38,7 +38,7 @@ describe('공지사항 카드 컴포넌트 테스트', () => {
     const annouceCards = screen.getAllByTestId('card');
     annouceCards.forEach(async (card, idx) => {
       await userEvent.click(card);
-      expect(window.location.href).toBe(announceList[idx].path);
+      expect(window.location.href).toBe(announceList[idx].link);
     });
   });
 });

--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { AnnounceItem } from '@type/announcement';
 
-const AnnounceCard = ({ title, path, date }: AnnounceItem) => {
+const AnnounceCard = ({ title, link, uploadDate }: AnnounceItem) => {
   const onClick = () => {
-    window.location.href = path;
+    window.location.href = link;
   };
   return (
     <Card onClick={onClick} data-testid="card">
@@ -23,7 +23,7 @@ const AnnounceCard = ({ title, path, date }: AnnounceItem) => {
             margin: 0 10px;
           `}
         />
-        <span>{date}</span>
+        <span>{uploadDate}</span>
       </div>
     </Card>
   );


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
* Closes: #99 
* 백엔드 공지사항 데이터와 스키마 통일했어요.
* AnnounceCard가 받는 props를 수정해 외부 링크로 이동할 수 있게 했어요.

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
