### PR TITLE
Fix/#102: 공지사항 선택 시 특정 학과는 공지 안보이는 에러 수정

### DIFF
--- a/src/components/List/DepartmentList/index.test.tsx
+++ b/src/components/List/DepartmentList/index.test.tsx
@@ -1,6 +1,6 @@
 import DepartmentList from '@components/List/DepartmentList';
 import useMajor from '@hooks/useMajor';
-import { render, act, screen } from '@testing-library/react';
+import { render, act, screen, findByText } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -72,5 +72,27 @@ describe('학과선택 테스트', () => {
 
     expect(mockSetMajor).toBeCalledWith('컴퓨터인공지능학부');
     expect(routerToMock).toBeCalledWith('/');
+  });
+
+  it('학과 이름에 스페이스가 있는 경우 (학부, 전공이 모두 있는경우) 테스트', async () => {
+    const collegName = '정보융합대학';
+    render(
+      <MemoryRouter initialEntries={[`/major-decision/${collegName}`]}>
+        <Routes>
+          <Route path="/major-decision/:college" element={<DepartmentList />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const confirmButton = await screen.findByRole('button', {
+      name: '선택완료',
+    });
+    const college = await screen.findByText('조형학부 건축학전공');
+    await act(async () => {
+      await userEvent.click(college);
+    });
+    await userEvent.click(confirmButton);
+
+    expect(mockSetMajor).toBeCalledWith('건축학전공');
   });
 });

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -32,8 +32,9 @@ const DepartmentList = () => {
 
   const buttonClick: React.MouseEventHandler<HTMLElement> = (e) => {
     if (e.target !== e.currentTarget) return;
-    localStorage.setItem('major', selected);
-    setMajor(selected);
+    const afterSpace = selected.substring(selected.indexOf(' ') + 1);
+    localStorage.setItem('major', afterSpace);
+    setMajor(afterSpace);
     alert('전공 선택 완료 !');
     routerTo('/');
   };

--- a/src/mocks/handlers/majorHandlers.ts
+++ b/src/mocks/handlers/majorHandlers.ts
@@ -13,6 +13,7 @@ export const majorHandlers: RequestHandler[] = [
         '데이터정보과학부',
         '미디어커뮤니케이션학부',
         '컴퓨터인공지능학부',
+        '조형학부 건축학전공',
       ];
       return res(ctx.status(200), ctx.json(INFORMATIONCONVERGENCE));
     }


### PR DESCRIPTION
## 🤠 개요

- Closes: #102 
- 공지사항 선택 시 학부/학과, 전공이 모두 있는 학과는 전공값만 로컬 스토리지에 저장하여 사용하도록 수정했어요 (서버에서 그렇게 처리하기 때문이에요)
- 예를들어 `조형학부 건축학전공` 인 경우 `건축학전공` 으로 저장하도록 변경했어요!
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
