### PR TITLE
Feat/#93: 지도 페이지 구현

### DIFF
--- a/.env.vault
+++ b/.env.vault
@@ -2,11 +2,10 @@
 #/         cloud-agnostic vaulting standard         /
 #/   [how it works](https://dotenv.org/env-vault)   /
 #/--------------------------------------------------/
-DOTENV_VAULT=vlt_97eb9d6fce27471a5ff6b62c040cfc4ab07624d075749dc2475497577347fda5
 
 # development
-DOTENV_VAULT_DEVELOPMENT="+7rnjb731Ll+/8g6pDbk6caT98Q8WD0IQp8gNTJ9A2OW73RBZX0hnOrIVkfcCFIneP4BgbAuSOxtRg7XWVQiC8tu6PXo5Ri/fo34ZcxTfVppXXgLrIJPs161QjVXEbvOJMI81UM="
-DOTENV_VAULT_DEVELOPMENT_VERSION=4
+DOTENV_VAULT_DEVELOPMENT="ijIIgAnOwdWEyUDz+YZp00Sk1LS25brvrzrZD+tOXPfl4dXeqSCKWLLf8jBwz5DA6xYt5U8huwenZkcV8zevx5+NhORZTX5w75a9BqBlw6SGlHSMz9EyZ9Cypjr+9gl0yvZtOzt+ss4e6v/MFxDUdJ+g34VjqTpURpYfqwEmVO6IDmIC+9QqCnYslMyf361FEIdsY2Wlyk+wz3xeUUWasg=="
+DOTENV_VAULT_DEVELOPMENT_VERSION=5
 
 # ci
 DOTENV_VAULT_CI="Ud/ESvFO1RTmXHns/q9lepggbzQvju4Dz+q4+NFBUSdGJSy1in1vBzuSb6FekmdeaRiveJh2W48="
@@ -19,3 +18,8 @@ DOTENV_VAULT_STAGING_VERSION=4
 # production
 DOTENV_VAULT_PRODUCTION="3ZBg4tewldPPP0ol5qEHnTgxmpsW5v6wjzwDuwilmJIrSmKGUH8EYK0sD3NcLMmE+CIkuMM3+Dmo4TcZ6qF/4HebAR0Rdr44oY+9Z90k2g=="
 DOTENV_VAULT_PRODUCTION_VERSION=4
+
+#/----------------settings/metadata-----------------/
+DOTENV_VAULT="vlt_97eb9d6fce27471a5ff6b62c040cfc4ab07624d075749dc2475497577347fda5"
+DOTENV_API_URL="https://vault.dotenv.org"
+DOTENV_CLI="npx dotenv-vault@latest"

--- a/index.html
+++ b/index.html
@@ -16,5 +16,10 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script
+      type="text/javascript"
+      strategy="beforeInteractive"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAOMAP_API_KEY%&libraries=services,clusterer,drawing"
+    ></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Header from '@components/Header';
 import Announcement from '@pages/Announcement';
 import Home from '@pages/Home';
 import MajorDecision from '@pages/MajorDecision';
+import Map from '@pages/Map';
 import My from '@pages/My';
 import { Routes, Route } from 'react-router-dom';
 
@@ -14,6 +15,7 @@ const App = () => {
         <Route path="/" element={<Home />} />
         <Route path="/announcement" element={<Announcement />} />
         <Route path="/my" element={<My />} />
+        <Route path="/map" element={<Map />} />
         <Route path="/major-decision/*" element={<MajorDecision />} />
       </Routes>
       <FooterTab />

--- a/src/components/FooterTab/index.tsx
+++ b/src/components/FooterTab/index.tsx
@@ -43,15 +43,18 @@ const FooterTab = () => {
 const Footer = styled.div`
   // Footer 스타일 컴포넌트 수정
   max-width: 480px;
-
+  padding: 10px;
   position: fixed;
   left: 50%;
   bottom: 0;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   width: 100%;
+
+  height: 5vh;
 
   display: flex;
   justify-content: space-around;
+  align-items: center;
 `;
 
 const IconContainer = styled.div`

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,18 +1,20 @@
 import Icon from '@components/Icon';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import useRouter from '@hooks/useRouter';
+import useRoter from '@hooks/useRouter';
 import React from 'react';
 
 const Header = () => {
-  const { routerTo, goBack } = useRouter();
+  const { routerTo, goBack } = useRoter();
   return (
     <header
       css={css`
         display: flex;
         justify-content: space-between;
+        align-items: center;
 
-        padding: 5px 10px;
+        padding: 10px;
+        height: 5vh;
       `}
     >
       <Icon kind="arrowBack" onClick={goBack} />

--- a/src/components/Modal/MapBoundsLimitModal/index.tsx
+++ b/src/components/Modal/MapBoundsLimitModal/index.tsx
@@ -1,0 +1,28 @@
+import Modal from '@components/Modal';
+import { css } from '@emotion/react';
+import { THEME } from '@styles/ThemeProvider/theme';
+import React from 'react';
+
+interface MapBoundsLimitModal {
+  onClose: () => void;
+}
+
+const MapBoundsLimitModal = ({ onClose }: MapBoundsLimitModal) => {
+  return (
+    <Modal onClose={onClose}>
+      <>
+        <span
+          css={css`
+            color: ${THEME.TEXT.GRAY};
+            font-weight: bold;
+            margin: 0 auto;
+          `}
+        >
+          앗! 지도의 범위를 벗어났어요.
+        </span>
+      </>
+    </Modal>
+  );
+};
+
+export default MapBoundsLimitModal;

--- a/src/components/Modal/MapLevelLimitModal/index.tsx
+++ b/src/components/Modal/MapLevelLimitModal/index.tsx
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import { THEME } from '@styles/ThemeProvider/theme';
+
+import Modal from '..';
+
+interface MapLevetLimitModalProps {
+  onClose: () => void;
+}
+
+const MapLevetLimitModal = ({ onClose }: MapLevetLimitModalProps) => {
+  return (
+    <Modal onClose={onClose}>
+      <>
+        <span
+          css={css`
+            color: ${THEME.TEXT.GRAY};
+            font-weight: bold;
+            margin: 0 auto;
+          `}
+        >
+          앗! 지도를 더이상 축소할 수 없어요
+        </span>
+      </>
+    </Modal>
+  );
+};
+
+export default MapLevetLimitModal;

--- a/src/constants/pknu-map.ts
+++ b/src/constants/pknu-map.ts
@@ -1,0 +1,238 @@
+interface PknuBuilding {
+  readonly buildingNumber: string;
+  readonly buildingName: string;
+  readonly latlng: [number, number];
+}
+
+export const PKNU_BUILDINGS: readonly PknuBuilding[] = [
+  {
+    buildingNumber: 'A11',
+    buildingName: '대학본부',
+    latlng: [35.134009202001316, 129.10309425666023],
+  },
+  {
+    buildingNumber: 'A12',
+    buildingName: '웅비관',
+    latlng: [35.13448507894045, 129.10319425736515],
+  },
+  {
+    buildingNumber: 'A13',
+    buildingName: '누리관',
+    latlng: [35.13477742833195, 129.10309482297396],
+  },
+  {
+    buildingNumber: 'A15',
+    buildingName: '워커하우스',
+    latlng: [35.13541800394449, 129.10382983225276],
+  },
+  {
+    buildingNumber: 'A15',
+    buildingName: '향파관',
+    latlng: [35.135348948698365, 129.10287641587055],
+  },
+  {
+    buildingNumber: 'A21',
+    buildingName: '미래관',
+    latlng: [35.133959884079516, 129.10217153151783],
+  },
+  {
+    buildingNumber: 'A22',
+    buildingName: '디자인관',
+    latlng: [35.13425800209641, 129.10147987520727],
+  },
+  {
+    buildingNumber: 'A23',
+    buildingName: '나래관',
+    latlng: [35.13486547457253, 129.10178619206036],
+  },
+  {
+    buildingNumber: 'A26',
+    buildingName: '부산창업카페 2호점',
+    latlng: [35.135198384658516, 129.10116672530137],
+  },
+  {
+    buildingNumber: 'B11',
+    buildingName: '위드센터',
+    latlng: [35.133987101586925, 129.10566334469846],
+  },
+
+  {
+    buildingNumber: 'B12',
+    buildingName: '나비센터',
+    latlng: [35.13405879317518, 129.10633434445595],
+  },
+  {
+    buildingNumber: 'B13',
+    buildingName: '충무관',
+    latlng: [35.13503097184985, 129.1052294985021],
+  },
+  {
+    buildingNumber: 'B14',
+    buildingName: '환경해양관',
+    latlng: [35.135040804141354, 129.10634867710766],
+  },
+  {
+    buildingNumber: 'B15',
+    buildingName: '자연과학1관',
+    latlng: [35.13555903353968, 129.10543781395603],
+  },
+  {
+    buildingNumber: 'B16',
+    buildingName: '수위실(후문)',
+    latlng: [35.13625012336413, 129.1065059931721],
+  },
+  {
+    buildingNumber: 'B21',
+    buildingName: '가온관',
+    latlng: [35.13401856418254, 129.1050196840027],
+  },
+  {
+    buildingNumber: 'B22',
+    buildingName: '청운관',
+    latlng: [35.134428237691154, 129.10478067047796],
+  },
+  {
+    buildingNumber: 'C11',
+    buildingName: '수산질병관리원',
+    latlng: [35.13377917592698, 129.10868013710467],
+  },
+  {
+    buildingNumber: 'C12',
+    buildingName: '장영실관',
+    latlng: [35.13481165172098, 129.1089014835836],
+  },
+  {
+    buildingNumber: 'C13',
+    buildingName: '해양공동연구관',
+    latlng: [35.13545371419755, 129.10877269623805],
+  },
+  {
+    buildingNumber: 'C14',
+    buildingName: '부경대학교 어린이집',
+    latlng: [35.13488945181894, 129.10947940662655],
+  },
+  {
+    buildingNumber: 'C21',
+    buildingName: '수산과학관',
+    latlng: [35.133540074964145, 129.10779091303866],
+  },
+  {
+    buildingNumber: 'C22',
+    buildingName: '건축관',
+    latlng: [35.134692788637274, 129.10770545102733],
+  },
+  {
+    buildingNumber: 'C23',
+    buildingName: '호연관',
+    latlng: [35.135246989425255, 129.10770602771154],
+  },
+  {
+    buildingNumber: 'C24',
+    buildingName: '자연과학2관',
+    latlng: [35.13567570498883, 129.10766771682054],
+  },
+  {
+    buildingNumber: 'C25',
+    buildingName: '인문사회경영관',
+    latlng: [35.13422315762162, 129.1077646460986],
+  },
+
+  {
+    buildingNumber: 'C26',
+    buildingName: '해양수산LMO격리사육동',
+    latlng: [35.1330329, 129.1073065],
+  },
+  {
+    buildingNumber: 'C27',
+    buildingName: '수조실험동',
+    latlng: [35.133012828243714, 129.1075359886025],
+  },
+  {
+    buildingNumber: 'C28',
+    buildingName: '아름관',
+    latlng: [35.13303461466008, 129.1079671063524],
+  },
+  {
+    buildingNumber: 'D12',
+    buildingName: '테니스장',
+    latlng: [35.13187281113036, 129.1065028981342],
+  },
+  {
+    buildingNumber: 'D13',
+    buildingName: '대운동장',
+    latlng: [35.1326944387007, 129.1062827382093],
+  },
+  {
+    buildingNumber: 'D14',
+    buildingName: '한울관',
+    latlng: [35.13233118040464, 129.1069617150524],
+  },
+  {
+    buildingNumber: 'D21',
+    buildingName: '대학극장',
+    latlng: [35.13237660740733, 129.10499660318473],
+  },
+  {
+    buildingNumber: 'D22',
+    buildingName: '체육관',
+    latlng: [35.133109374732555, 129.10496336478204],
+  },
+  {
+    buildingNumber: 'D23',
+    buildingName: '안전관리관',
+    latlng: [35.132382375868424, 129.1051832332297],
+  },
+  {
+    buildingNumber: 'D24',
+    buildingName: '수상레저관',
+    latlng: [35.13266402562087, 129.10492173196255],
+  },
+  {
+    buildingNumber: 'E11',
+    buildingName: '세종1관',
+    latlng: [35.1312221, 129.1049895],
+  },
+  {
+    buildingNumber: 'E12',
+    buildingName: '세종2관',
+    latlng: [35.13121085834351, 129.10414663049266],
+  },
+  {
+    buildingNumber: 'E13',
+    buildingName: '공학1관',
+    latlng: [35.13164265713184, 129.1034118237889],
+  },
+  {
+    buildingNumber: 'E14',
+    buildingName: '학술정보관',
+    latlng: [35.13265930161191, 129.10376706621912],
+  },
+  {
+    buildingNumber: 'E21',
+    buildingName: '공학2관',
+    latlng: [35.13161038816922, 129.1028049341183],
+  },
+  {
+    buildingNumber: 'E22',
+    buildingName: '동원 장보고관',
+    latlng: [35.13317876403389, 129.10291383413244],
+  },
+  {
+    buildingNumber: 'E29',
+    buildingName: '양어장관리사',
+    latlng: [35.1330880354213, 129.10152110317765],
+  },
+];
+
+export const PKNU_MAP_LIMIT = {
+  LEVEL: 4,
+  TOP: 35.14126547655272,
+  RIGHT: 129.11383219075216,
+  BOTTOM: 35.12545545221074,
+  LEFT: 129.09694451219139,
+} as const;
+
+export const PKNU_MAP_CENTER = {
+  LAT: 35.132990223842,
+  LNG: 129.1052030382,
+} as const;

--- a/src/pages/Map/MapLevelObserver.tsx
+++ b/src/pages/Map/MapLevelObserver.tsx
@@ -1,0 +1,38 @@
+import MapLevetLimitModal from '@components/Modal/MapLevelLimitModal';
+import { PKNU_MAP_LIMIT } from '@constants/pknu-map';
+import React, { useEffect, useState } from 'react';
+
+interface MapLevelObserverProps {
+  map: any;
+  centerLocation: any;
+}
+
+const MapLevelObserver = ({ map, centerLocation }: MapLevelObserverProps) => {
+  if (!map) {
+    return null;
+  }
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    const levelLimitHandler = () => {
+      if (map.getLevel() <= PKNU_MAP_LIMIT.LEVEL) {
+        return;
+      }
+      map.setLevel(PKNU_MAP_LIMIT.LEVEL);
+      map.setCenter(centerLocation);
+      setIsModalOpen((prev) => !prev);
+    };
+    window.kakao.maps.event.addListener(map, 'zoom_changed', levelLimitHandler);
+  });
+
+  return (
+    <>
+      {isModalOpen && (
+        <MapLevetLimitModal onClose={() => setIsModalOpen((prev) => !prev)} />
+      )}
+    </>
+  );
+};
+
+export default MapLevelObserver;

--- a/src/pages/Map/MapboundaryObserver.tsx
+++ b/src/pages/Map/MapboundaryObserver.tsx
@@ -1,0 +1,50 @@
+import MapBoundsLimitModal from '@components/Modal/MapBoundsLimitModal';
+import { PKNU_MAP_LIMIT } from '@constants/pknu-map';
+import React, { useEffect, useState } from 'react';
+
+interface MapBounds {
+  map: any;
+  centerLocation: any;
+}
+
+const MapboundaryObserver = ({ map, centerLocation }: MapBounds) => {
+  if (!map) {
+    return null;
+  }
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  useEffect(() => {
+    const boundayLimitHandler = () => {
+      const { La, Ma } = map.getCenter();
+      if (
+        Ma >= PKNU_MAP_LIMIT.TOP ||
+        La >= PKNU_MAP_LIMIT.RIGHT ||
+        Ma <= PKNU_MAP_LIMIT.BOTTOM ||
+        La <= PKNU_MAP_LIMIT.LEFT
+      ) {
+        setIsModalOpen((prev) => !prev);
+        map.setLevel(4);
+        map.setCenter(centerLocation);
+      }
+    };
+    window.kakao.maps.event.addListener(map, 'dragend', boundayLimitHandler);
+
+    return () => {
+      window.kakao.maps.event.removeListener(
+        map,
+        'dragend',
+        boundayLimitHandler,
+      );
+    };
+  }, []);
+
+  return (
+    <>
+      {isModalOpen && (
+        <MapBoundsLimitModal onClose={() => setIsModalOpen((prev) => !prev)} />
+      )}
+    </>
+  );
+};
+
+export default MapboundaryObserver;

--- a/src/pages/Map/PknuBuildingNumbers.tsx
+++ b/src/pages/Map/PknuBuildingNumbers.tsx
@@ -1,0 +1,33 @@
+import { PKNU_BUILDINGS } from '@constants/pknu-map';
+import React from 'react';
+
+interface BuildingNumbersProps {
+  map: any;
+}
+
+const PknuBuildingNumbers = ({ map }: BuildingNumbersProps) => {
+  if (!map) {
+    return null;
+  }
+
+  return (
+    <>
+      {PKNU_BUILDINGS.forEach((PKNU_BUILDING) => {
+        new window.kakao.maps.CustomOverlay({
+          map: map,
+          position: new window.kakao.maps.LatLng(
+            PKNU_BUILDING.latlng[0],
+            PKNU_BUILDING.latlng[1],
+          ),
+          content: `<span style="display: block; background: #71BC5C; color: #fff; text-align: center; padding: 5px; border-radius: 8px; font-size:12px; font-weight: bold;">
+          ${PKNU_BUILDING.buildingNumber}
+        </span>`,
+          removable: false,
+          yAnchor: -0.05,
+        });
+      })}
+    </>
+  );
+};
+
+export default PknuBuildingNumbers;

--- a/src/pages/Map/index.tsx
+++ b/src/pages/Map/index.tsx
@@ -1,0 +1,58 @@
+import { PKNU_MAP_CENTER } from '@constants/pknu-map';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+
+import MapboundaryObserver from './MapboundaryObserver';
+import MapLevelObserver from './MapLevelObserver';
+import PknuBuildingNumbers from './PknuBuildingNumbers';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+const Map = () => {
+  const [map, setMap] = useState(null);
+  const PKNU_MAP_CENTER_LOCATION = new window.kakao.maps.LatLng(
+    PKNU_MAP_CENTER.LAT,
+    PKNU_MAP_CENTER.LNG,
+  );
+  useEffect(() => {
+    const container = document.getElementById('map');
+    const options = {
+      center: PKNU_MAP_CENTER_LOCATION,
+      level: 4,
+    };
+    const map = new window.kakao.maps.Map(container, options);
+    setMap(map);
+  }, []);
+
+  return (
+    <div
+      css={css`
+        height: calc(90vh - 40px);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      `}
+    >
+      <KakaoMap id="map" />
+      <PknuBuildingNumbers map={map} />
+      <MapLevelObserver map={map} centerLocation={PKNU_MAP_CENTER_LOCATION} />
+      <MapboundaryObserver
+        map={map}
+        centerLocation={PKNU_MAP_CENTER_LOCATION}
+      />
+    </div>
+  );
+};
+
+export default Map;
+
+const KakaoMap = styled.div`
+  width: 100%;
+  height: 100%;
+  border-radius: 15px;
+`;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
* Closes: #93 
* 지도 페이지 구현했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->

* 카카오 지도 API
  * index.html 파일의 script 태그를 통해서 카카오지도를 사용하기 위한 API_KEY를 환경변수를 사용해서 등록했어요.
  * 설저해놓은 축소레벨, 지도의 범위를 벗어나게 되면 경고 모달창을 렌더링 하고 사용자를 기본위치로 다시 이동시켜요. 확대레벨 제한은 없어요
  * 사용자의 위치는 보안상의 이유로 https 환경에서만 설정이 가능해요. 따라서, http 환경인 로컬서버에서는 위치를 확인할 수 없어서 개발하는데 제한이 있었어요. 따라서 일단 사용자의 위치 렌더링은 보류 했어요.

## ✅ 얻은점
* 번들러에 따라서 환경변수 설정법이 다르다
  * vite, cra등의 번들러마다 환경변수 설정법이 다르기 때문에, 번들러 환경에 따라서 환경변수 설정을 다르게 해줘야 한다는 것을 배웠어요.
## ✅ 앞으로의 개선점 
* 개발이 진행됨에 따라 모달을 사용하는 컴포넌트가 꽤 많아지는데, 모달의 렌더링 상태를 전역상태로 관리하는게 더 괜찮을 것 같아요.

## 📷 스크린샷 (Optional)
<img width="501" alt="Screenshot 2023-07-21 at 15 13 30" src="https://github.com/hwinkr/algorithm/assets/68489467/35a8059a-e6a3-4e97-9f3a-bd46e79c3eb5">


https://github.com/hwinkr/algorithm/assets/68489467/744de551-f54d-484a-ba3b-15b9785b4d5f

https://github.com/hwinkr/algorithm/assets/68489467/5d409274-6aac-43fa-991b-112e2ff3520d