### PR TITLE
Feat/#105: 건의사항 작성 시 한번더 확인하기 구현 & 모달 전역상태로 변경

### DIFF
--- a/src/@types/modals.ts
+++ b/src/@types/modals.ts
@@ -1,0 +1,8 @@
+import { FunctionComponent } from 'react';
+
+export type Modals =
+  | Array<{
+      Component: FunctionComponent<any>;
+      props: object;
+    }>
+  | [];

--- a/src/@types/styles/icon.ts
+++ b/src/@types/styles/icon.ts
@@ -11,4 +11,5 @@ export type IconKind =
   | 'suggest'
   | 'right'
   | 'checkedRadio'
-  | 'uncheckedRadio';
+  | 'uncheckedRadio'
+  | 'cancel';

--- a/src/components/Card/InformCard/index.test.tsx
+++ b/src/components/Card/InformCard/index.test.tsx
@@ -1,4 +1,8 @@
+import AlertModal from '@components/Modal/AlertModal';
+import ModalsProvider from '@components/ModalsProvider';
+import { MODAL_MESSAGE } from '@constants/modal-messages';
 import MajorContext from '@contexts/major';
+import useModals from '@hooks/useModals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Major from '@type/major';
@@ -12,8 +16,8 @@ const ICON = 'notification';
 const TITLE = '공지사항';
 const PATH = '/announcement';
 
-const setMajorMock = (mode: string) => {
-  const mockMajor: Major = mode === 'modal' ? null : '컴퓨터공학과';
+const setMajorMock = (isRender: boolean) => {
+  const mockMajor: Major = isRender ? null : '컴퓨터공학과';
   const mockSetMajor = jest.fn();
 
   jest.mock('react', () => ({
@@ -33,6 +37,18 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockRouterTo,
 }));
 
+jest.mock('@hooks/useModals', () => {
+  const modalsMock = {
+    modals: [],
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    default: () => modalsMock,
+  };
+});
+
 describe('InformCard 컴포넌트 테스트', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -40,8 +56,10 @@ describe('InformCard 컴포넌트 테스트', () => {
 
   it('전역상태가 설정 됐을 경우, 페이지 이동 테스트', async () => {
     render(
-      <MajorContext.Provider value={{ ...setMajorMock('not-modal') }}>
-        <InformCard icon={ICON} title={TITLE} path={PATH} />
+      <MajorContext.Provider value={{ ...setMajorMock(false) }}>
+        <ModalsProvider>
+          <InformCard icon={ICON} title={TITLE} path={PATH} />
+        </ModalsProvider>
       </MajorContext.Provider>,
       {
         wrapper: MemoryRouter,
@@ -58,8 +76,10 @@ describe('InformCard 컴포넌트 테스트', () => {
 
   it('전역상태가 설정 안됐을 경우, 모달 렌더링 테스트', async () => {
     render(
-      <MajorContext.Provider value={{ ...setMajorMock('modal') }}>
-        <InformCard icon={ICON} title={TITLE} path={PATH} />
+      <MajorContext.Provider value={{ ...setMajorMock(true) }}>
+        <ModalsProvider>
+          <InformCard icon={ICON} title={TITLE} path={PATH} />
+        </ModalsProvider>
       </MajorContext.Provider>,
       {
         wrapper: MemoryRouter,
@@ -71,8 +91,12 @@ describe('InformCard 컴포넌트 테스트', () => {
       await userEvent.click(card);
     });
 
-    expect(
-      screen.getByText('아직 학과를 알려주지 않았어요'),
-    ).toBeInTheDocument();
+    expect(useModals().openModal).toHaveBeenCalledWith(AlertModal, {
+      message: MODAL_MESSAGE.ALERT.setMajor,
+      buttonMessage: '전공선택하러 가기',
+      iconKind: 'plus',
+      onClose: expect.any(Function),
+      routerTo: expect.any(Function),
+    });
   });
 });

--- a/src/components/Card/InformCard/index.test.tsx
+++ b/src/components/Card/InformCard/index.test.tsx
@@ -92,7 +92,7 @@ describe('InformCard 컴포넌트 테스트', () => {
     });
 
     expect(useModals().openModal).toHaveBeenCalledWith(AlertModal, {
-      message: MODAL_MESSAGE.ALERT.setMajor,
+      message: MODAL_MESSAGE.ALERT.SET_MAJOR,
       buttonMessage: '전공선택하러 가기',
       iconKind: 'plus',
       onClose: expect.any(Function),

--- a/src/components/Card/InformCard/index.tsx
+++ b/src/components/Card/InformCard/index.tsx
@@ -31,7 +31,7 @@ const InformCard = ({ icon, title, path }: InformCardProps) => {
       return;
     }
     openModal(AlertModal, {
-      message: MODAL_MESSAGE.ALERT.setMajor,
+      message: MODAL_MESSAGE.ALERT.SET_MAJOR,
       buttonMessage: '전공선택하러 가기',
       iconKind: 'plus',
       onClose: () => closeModal(AlertModal),

--- a/src/components/Card/InformCard/index.tsx
+++ b/src/components/Card/InformCard/index.tsx
@@ -1,13 +1,14 @@
 import Icon from '@components/Icon';
-import MajorModal from '@components/Modal/MajorModal';
+import AlertModal from '@components/Modal/AlertModal';
+import { MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
+import useModals from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { IconKind } from '@type/styles/icon';
 import { setSize } from '@utils/styles/size';
-import { useState } from 'react';
 
 interface InformCardProps {
   icon: IconKind & ('school' | 'notification');
@@ -17,26 +18,33 @@ interface InformCardProps {
 
 const InformCard = ({ icon, title, path }: InformCardProps) => {
   const { major } = useMajor();
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const { routerTo } = useRouter();
 
-  const onClick = () => {
-    if (!major) {
-      setIsModalOpen((prev) => !prev);
+  const { routerTo } = useRouter();
+  const routerToPath = (path: string) => routerTo(path);
+  const routerToMajorDecision = () => routerTo('/major-decision');
+
+  const { openModal, closeModal } = useModals();
+
+  const handleMajorModal = () => {
+    if (major) {
+      routerToPath(path);
       return;
     }
-    routerTo(path);
+    openModal(AlertModal, {
+      message: MODAL_MESSAGE.ALERT.setMajor,
+      buttonMessage: '전공선택하러 가기',
+      iconKind: 'plus',
+      onClose: () => closeModal(AlertModal),
+      routerTo: () => {
+        closeModal(AlertModal);
+        routerToMajorDecision();
+      },
+    });
   };
 
   return (
     <>
-      {isModalOpen && (
-        <MajorModal
-          onClose={() => setIsModalOpen((prev) => !prev)}
-          routerTo={() => routerTo('major-decision')}
-        />
-      )}
-      <Card data-testid="card" icon={icon} onClick={onClick}>
+      <Card data-testid="card" icon={icon} onClick={handleMajorModal}>
         <Icon
           kind={icon}
           color={icon === 'school' ? THEME.TEXT.GRAY : THEME.TEXT.WHITE}

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -14,6 +14,7 @@ import {
   MdOutlineQuestionAnswer,
   MdRadioButtonUnchecked,
   MdRadioButtonChecked,
+  MdOutlineCancel,
 } from 'react-icons/md';
 
 const ICON: { [key in IconKind]: IconType } = {
@@ -30,6 +31,7 @@ const ICON: { [key in IconKind]: IconType } = {
   suggest: MdOutlineQuestionAnswer,
   checkedRadio: MdRadioButtonChecked,
   uncheckedRadio: MdRadioButtonUnchecked,
+  cancel: MdOutlineCancel,
 };
 
 interface IconProps {

--- a/src/components/List/DepartmentList/index.test.tsx
+++ b/src/components/List/DepartmentList/index.test.tsx
@@ -1,5 +1,10 @@
 import DepartmentList from '@components/List/DepartmentList';
+import MajorProvider from '@components/MajorProvider';
+import ConfirmModal from '@components/Modal/ConfirmModal';
+import ModalsProvider from '@components/ModalsProvider';
+import { MODAL_MESSAGE } from '@constants/modal-messages';
 import useMajor from '@hooks/useMajor';
+import useModals from '@hooks/useModals';
 import { render, act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -7,12 +12,23 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 const routerToMock = jest.fn();
 
 jest.mock('@hooks/useMajor');
-global.alert = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => routerToMock,
 }));
+
+jest.mock('@hooks/useModals', () => {
+  const modalsMock = {
+    modals: [],
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    default: () => modalsMock,
+  };
+});
 
 describe('학과선택 테스트', () => {
   const mockUseMajor = useMajor as jest.MockedFunction<typeof useMajor>;
@@ -28,11 +44,17 @@ describe('학과선택 테스트', () => {
   it('버튼 활성화 테스트', async () => {
     const collegName = '정보융합대학';
     render(
-      <MemoryRouter initialEntries={[`/major-decision/${collegName}`]}>
-        <Routes>
-          <Route path="/major-decision/:college" element={<DepartmentList />} />
-        </Routes>
-      </MemoryRouter>,
+      <ModalsProvider>
+        <MemoryRouter initialEntries={[`/major-decision/${collegName}`]}>
+          <Routes>
+            <Route
+              path="/major-decision/:college"
+              element={<DepartmentList />}
+            />
+          </Routes>
+        </MemoryRouter>
+        ,
+      </ModalsProvider>,
     );
 
     const confirmButton = await screen.findByRole('button', {
@@ -51,14 +73,21 @@ describe('학과선택 테스트', () => {
     expect(confirmButton).toBeEnabled();
   });
 
-  it('버튼 클릭 로직 테스트', async () => {
+  it('버튼 클릭시 전공선택 확인 모달 렌더링 테스트', async () => {
     const collegName = '정보융합대학';
     render(
-      <MemoryRouter initialEntries={[`/major-decision/${collegName}`]}>
-        <Routes>
-          <Route path="/major-decision/:college" element={<DepartmentList />} />
-        </Routes>
-      </MemoryRouter>,
+      <MajorProvider>
+        <ModalsProvider>
+          <MemoryRouter initialEntries={[`/major-decision/${collegName}`]}>
+            <Routes>
+              <Route
+                path="/major-decision/:college"
+                element={<DepartmentList />}
+              />
+            </Routes>
+          </MemoryRouter>
+        </ModalsProvider>
+      </MajorProvider>,
     );
 
     const confirmButton = await screen.findByRole('button', {
@@ -68,9 +97,14 @@ describe('학과선택 테스트', () => {
     await act(async () => {
       await userEvent.click(college);
     });
-    await userEvent.click(confirmButton);
+    await act(async () => {
+      await userEvent.click(confirmButton);
+    });
 
-    expect(mockSetMajor).toBeCalledWith('컴퓨터인공지능학부');
-    expect(routerToMock).toBeCalledWith('/');
+    expect(useModals().openModal).toHaveBeenCalledWith(ConfirmModal, {
+      message: MODAL_MESSAGE.CONFIRM.setMajor,
+      onCancelButtonClick: expect.any(Function),
+      onConfirmButtonClick: expect.any(Function),
+    });
   });
 });

--- a/src/components/List/DepartmentList/index.test.tsx
+++ b/src/components/List/DepartmentList/index.test.tsx
@@ -53,7 +53,6 @@ describe('학과선택 테스트', () => {
             />
           </Routes>
         </MemoryRouter>
-        ,
       </ModalsProvider>,
     );
 
@@ -102,7 +101,7 @@ describe('학과선택 테스트', () => {
     });
 
     expect(useModals().openModal).toHaveBeenCalledWith(ConfirmModal, {
-      message: MODAL_MESSAGE.CONFIRM.setMajor,
+      message: MODAL_MESSAGE.CONFIRM.SET_MAJOR,
       onCancelButtonClick: expect.any(Function),
       onConfirmButtonClick: expect.any(Function),
     });

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -42,7 +42,7 @@ const DepartmentList = () => {
     setMajor(selected);
 
     openModal(AlertModal, {
-      message: MODAL_MESSAGE.SUCCEED.setMajor,
+      message: MODAL_MESSAGE.SUCCEED.SET_MAJOR,
       buttonMessage: '홈으로 이동하기',
       onClose: () => routerToHome(),
       routerTo: () => routerToHome(),
@@ -51,7 +51,7 @@ const DepartmentList = () => {
 
   const handleMajorConfirmModal = () => {
     openModal(ConfirmModal, {
-      message: MODAL_MESSAGE.CONFIRM.setMajor,
+      message: MODAL_MESSAGE.CONFIRM.SET_MAJOR,
       onConfirmButtonClick: () => handlerMajorSetModal(),
       onCancelButtonClick: () => closeModal(ConfirmModal),
     });

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -1,8 +1,12 @@
 import http from '@apis/http';
 import Button from '@components/Button';
 import Icon from '@components/Icon';
+import AlertModal from '@components/Modal/AlertModal';
+import ConfirmModal from '@components/Modal/ConfirmModal';
+import { MODAL_MESSAGE } from '@constants/modal-messages';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
+import useModals from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
 import React, { useEffect, useState } from 'react';
@@ -15,6 +19,7 @@ const DepartmentList = () => {
   const { routerTo, goBack } = useRouter();
   const { setMajor } = useMajor();
   const { college } = useParams();
+  const { openModal, closeModal } = useModals();
 
   const fetchData = async () => {
     const result = await http.get(`/api/majorDecision/${college}`);
@@ -23,24 +28,40 @@ const DepartmentList = () => {
     }
     setDepartmentList(result.data);
   };
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const routerToHome = () => {
+    closeModal(AlertModal);
+    routerTo('/');
+  };
+  const handlerMajorSetModal = () => {
+    closeModal(ConfirmModal);
+    localStorage.setItem('major', selected);
+    setMajor(selected);
+
+    openModal(AlertModal, {
+      message: MODAL_MESSAGE.SUCCEED.setMajor,
+      buttonMessage: '홈으로 이동하기',
+      onClose: () => routerToHome(),
+      routerTo: () => routerToHome(),
+    });
+  };
+
+  const handleMajorConfirmModal = () => {
+    openModal(ConfirmModal, {
+      message: MODAL_MESSAGE.CONFIRM.setMajor,
+      onConfirmButtonClick: () => handlerMajorSetModal(),
+      onCancelButtonClick: () => closeModal(ConfirmModal),
+    });
+  };
 
   const onClick: React.MouseEventHandler<HTMLElement> = (e) => {
     if (e.currentTarget.textContent === null) return;
     setSelected(e.currentTarget.textContent);
     setButtonDisable(false);
   };
-
-  const buttonClick: React.MouseEventHandler<HTMLElement> = (e) => {
-    if (e.target !== e.currentTarget) return;
-    localStorage.setItem('major', selected);
-    setMajor(selected);
-    alert('전공 선택 완료 !');
-    routerTo('/');
-  };
-
-  useEffect(() => {
-    fetchData();
-  }, []);
 
   return departmentList ? (
     <ListContainer>
@@ -57,7 +78,7 @@ const DepartmentList = () => {
         </ListWrapper>
       ))}
       <ButtonContainer>
-        <Button disabled={buttonDisable} onClick={buttonClick}>
+        <Button disabled={buttonDisable} onClick={handleMajorConfirmModal}>
           선택완료
         </Button>
       </ButtonContainer>

--- a/src/components/Modal/AlertModal/index.tsx
+++ b/src/components/Modal/AlertModal/index.tsx
@@ -7,11 +7,6 @@ import React from 'react';
 
 import Modal from '..';
 
-/*
-TODO
-1. 모달이 필요한 컴포넌트 내부에서 모달의 상태 관리 -> 모달이 필요한 컴포넌트는 모달상태를 관리하는 Context APIf를 통해서 모달의 상태를 내려받음.
-*/
-
 interface AlertModalProps {
   message: string;
   buttonMessage: string;
@@ -45,7 +40,7 @@ const AlertModal = ({
               {message}
             </span>
             <Button onClick={routerTo}>
-              {iconKind && <Icon kind="plus" color={THEME.TEXT.WHITE} />}
+              {iconKind && <Icon kind={iconKind} color={THEME.TEXT.WHITE} />}
               {buttonMessage}
             </Button>
           </>

--- a/src/components/Modal/AlertModal/index.tsx
+++ b/src/components/Modal/AlertModal/index.tsx
@@ -1,0 +1,58 @@
+import Button from '@components/Button';
+import Icon from '@components/Icon';
+import { css } from '@emotion/react';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { IconKind } from '@type/styles/icon';
+import React from 'react';
+
+import Modal from '..';
+
+/*
+TODO
+1. 모달이 필요한 컴포넌트 내부에서 모달의 상태 관리 -> 모달이 필요한 컴포넌트는 모달상태를 관리하는 Context APIf를 통해서 모달의 상태를 내려받음.
+*/
+
+interface AlertModalProps {
+  message: string;
+  buttonMessage: string;
+  open: boolean;
+  iconKind?: IconKind;
+  onClose: () => void;
+  routerTo?: () => void;
+}
+
+const AlertModal = ({
+  message,
+  buttonMessage,
+  open,
+  iconKind,
+  onClose,
+  routerTo = onClose,
+}: AlertModalProps) => {
+  return (
+    <>
+      {open && (
+        <Modal onClose={onClose}>
+          <>
+            <span
+              css={css`
+                color: ${THEME.TEXT.GRAY};
+                font-weight: bold;
+                margin: 0 auto;
+                margin-bottom: 15px;
+              `}
+            >
+              {message}
+            </span>
+            <Button onClick={routerTo}>
+              {iconKind && <Icon kind="plus" color={THEME.TEXT.WHITE} />}
+              {buttonMessage}
+            </Button>
+          </>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default AlertModal;

--- a/src/components/Modal/ConfirmModal/index.tsx
+++ b/src/components/Modal/ConfirmModal/index.tsx
@@ -1,0 +1,53 @@
+import Button from '@components/Button';
+import { css } from '@emotion/react';
+import { THEME } from '@styles/ThemeProvider/theme';
+import React from 'react';
+
+import Modal from '..';
+
+interface ConfirmModalProps {
+  message: string;
+  open: boolean;
+  onConfirmButtonClick: () => void;
+  onCancelButtonClick: () => void;
+}
+
+const ConfirmModal = ({
+  message,
+  open,
+  onConfirmButtonClick,
+  onCancelButtonClick,
+}: ConfirmModalProps) => {
+  return (
+    <>
+      {open && (
+        <Modal onClose={onCancelButtonClick}>
+          <>
+            <span
+              css={css`
+                color: ${THEME.TEXT.GRAY};
+                font-weight: bold;
+                margin: 0 auto;
+                margin-bottom: 15px;
+              `}
+            >
+              {message}
+            </span>
+            <div
+              css={css`
+                display: flex;
+                gap: 3.6rem;
+                justify-content: center;
+              `}
+            >
+              <Button onClick={onConfirmButtonClick}>네!</Button>
+              <Button onClick={onCancelButtonClick}>아니오</Button>
+            </div>
+          </>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/Modal/Modals/index.tsx
+++ b/src/components/Modal/Modals/index.tsx
@@ -1,0 +1,16 @@
+import useModals from '@hooks/useModals';
+import React from 'react';
+
+const Modals = () => {
+  const { modals } = useModals();
+
+  return (
+    <>
+      {modals.map(({ Component, props }, idx) => {
+        return <Component key={idx} {...props} />;
+      })}
+    </>
+  );
+};
+
+export default Modals;

--- a/src/components/Modal/SuggestionModal/index.tsx
+++ b/src/components/Modal/SuggestionModal/index.tsx
@@ -48,7 +48,7 @@ const SuggestionModal = ({
     onClose();
     closeModal(ConfirmModal);
     openModal(AlertModal, {
-      message: MODAL_MESSAGE.SUCCEED.postSuggestion,
+      message: MODAL_MESSAGE.SUCCEED.POST_SUGGESTION,
       buttonMessage: '확인',
       onClose: () => closeModal(AlertModal),
     });
@@ -56,7 +56,7 @@ const SuggestionModal = ({
 
   const handleSuggestionConfirmModal = () => {
     openModal(ConfirmModal, {
-      message: MODAL_MESSAGE.CONFIRM.postSuggestion,
+      message: MODAL_MESSAGE.CONFIRM.POST_SUGGESTION,
       onConfirmButtonClick: () => handleSuggestionPostModal(),
       onCancelButtonClick: () => closeModal(ConfirmModal),
     });

--- a/src/components/Modal/SuggestionModal/index.tsx
+++ b/src/components/Modal/SuggestionModal/index.tsx
@@ -1,24 +1,130 @@
-import React, { useState } from 'react';
+import http from '@apis/http';
+import Button from '@components/Button';
+import Icon from '@components/Icon';
+import { SERVER_URL } from '@config/index';
+import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import useModals from '@hooks/useModals';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { areaResize } from '@utils/styles/textarea-resize';
+import React, { useRef, useState } from 'react';
 
-import SuggestionInput from './SuggestionInput';
-import SuggestionThxMessage from './SuggestionThxMessage';
 import Modal from '..';
+import AlertModal from '../AlertModal';
+import ConfirmModal from '../ConfirmModal';
 
 interface SuggestionModalProps {
+  title: string;
+  buttonMessage: string;
   onClose: () => void;
 }
 
-const SuggestionModal = ({ onClose }: SuggestionModalProps) => {
-  const [isSended, setIsSended] = useState<boolean>(false);
+const SuggestionModal = ({
+  title,
+  buttonMessage,
+  onClose,
+}: SuggestionModalProps) => {
+  const areaRef = useRef<HTMLTextAreaElement>(null);
+  const [isInvalid, setIsInvalid] = useState<boolean>(true);
+  const { openModal, closeModal } = useModals();
+
+  const postSuggestion = async () => {
+    await http.post(
+      `${SERVER_URL}/api/suggestion`,
+      {
+        content: areaRef.current?.value,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  };
+
+  const handleSuggestionPostModal = () => {
+    postSuggestion();
+    onClose();
+    closeModal(ConfirmModal);
+    openModal(AlertModal, {
+      message: MODAL_MESSAGE.SUCCEED.postSuggestion,
+      buttonMessage: '확인',
+      onClose: () => closeModal(AlertModal),
+    });
+  };
+
+  const handleSuggestionConfirmModal = () => {
+    openModal(ConfirmModal, {
+      message: MODAL_MESSAGE.CONFIRM.postSuggestion,
+      onConfirmButtonClick: () => handleSuggestionPostModal(),
+      onCancelButtonClick: () => closeModal(ConfirmModal),
+    });
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (!e.currentTarget.value || e.currentTarget.value.length < 5) {
+      setIsInvalid(true);
+      return;
+    }
+    setIsInvalid(false);
+  };
+  const onResize = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    areaResize(e.currentTarget);
+  };
+
   return (
     <Modal onClose={onClose}>
-      {isSended ? (
-        <SuggestionThxMessage />
-      ) : (
-        <SuggestionInput setIsSended={setIsSended} />
-      )}
+      <>
+        <SuggestionHeader>
+          <span
+            css={css`
+              color: ${THEME.TEXT.BLACK};
+              font-weight: bold;
+            `}
+          >
+            {title}
+          </span>
+          <Icon kind="cancel" onClick={onClose} color={THEME.BUTTON.GREEN} />
+        </SuggestionHeader>
+        <SuggestionArea
+          minLength={5}
+          placeholder="건의사항을 5글자 이상 남겨주세요"
+          rows={1}
+          ref={areaRef}
+          onKeyDown={onResize}
+          onKeyUp={onResize}
+          onChange={onChange}
+        ></SuggestionArea>
+        <Button disabled={isInvalid} onClick={handleSuggestionConfirmModal}>
+          {buttonMessage}
+        </Button>
+      </>
     </Modal>
   );
 };
 
 export default SuggestionModal;
+
+const SuggestionArea = styled.textarea`
+  line-height: 1.5;
+  padding: 10px;
+  resize: none;
+  overflow-y: hidden;
+
+  font-size: 16px;
+  font-weight: bold;
+  border-radius: 8px;
+
+  &::placeholder {
+    color: ${THEME.TEXT.GRAY};
+    font-weight: lighter;
+  }
+`;
+
+const SuggestionHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+`;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,7 +1,7 @@
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { THEME } from '@styles/ThemeProvider/theme';
-import React, { useState } from 'react';
+import React from 'react';
 
 interface ModalProps {
   onClose: () => void;
@@ -9,18 +9,15 @@ interface ModalProps {
 }
 
 const Modal = ({ children, onClose }: ModalProps) => {
-  const [isOpen, setIsOpen] = useState<boolean>(true);
-
   const onClick = (e: React.MouseEvent<HTMLElement>) => {
     if (e.target === e.currentTarget) {
-      setIsOpen((prev) => !prev);
-      setTimeout(onClose, 200);
+      onClose();
     }
   };
 
   return (
     <ModalBackground onClick={onClick}>
-      <ModalContent isOpen={isOpen}>{children}</ModalContent>
+      <ModalContent>{children}</ModalContent>
     </ModalBackground>
   );
 };
@@ -39,20 +36,6 @@ const ModalBackground = styled.div`
   background-color: rgba(0, 0, 0, 0.6);
   z-index: 9999;
 `;
-
-const ModalContent = styled.div<{ isOpen: boolean }>`
-  display: flex;
-  flex-direction: column;
-
-  animation: ${({ isOpen }) => (isOpen ? modalIn : modalOut)} 0.3s ease-out;
-  width: 80%;
-  padding: 30px;
-  border-radius: 15px;
-  background-color: ${THEME.TEXT.WHITE};
-  color: ${THEME.TEXT.GRAY};
-  font-weight: bold;
-`;
-
 const modalIn = keyframes`
   from{
     opacity: 0;
@@ -64,13 +47,15 @@ const modalIn = keyframes`
   }
 `;
 
-const modalOut = keyframes`
-  from {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(-30px);
-  }
+const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  animation: ${modalIn} 0.3s ease-out;
+  width: 80%;
+  padding: 30px;
+  border-radius: 15px;
+  background-color: ${THEME.TEXT.WHITE};
+  color: ${THEME.TEXT.GRAY};
+  font-weight: bold;
 `;

--- a/src/components/ModalsProvider/index.tsx
+++ b/src/components/ModalsProvider/index.tsx
@@ -6,7 +6,7 @@ interface ModalsProviderProps {
   children: React.ReactNode;
 }
 
-const ModalsProvier = ({ children }: ModalsProviderProps) => {
+const ModalsProvider = ({ children }: ModalsProviderProps) => {
   const [modals, setModals] = useState<Modals>([]);
   return (
     <ModalsContext.Provider value={{ modals, setModals }}>
@@ -15,4 +15,4 @@ const ModalsProvier = ({ children }: ModalsProviderProps) => {
   );
 };
 
-export default ModalsProvier;
+export default ModalsProvider;

--- a/src/components/ModalsProvider/index.tsx
+++ b/src/components/ModalsProvider/index.tsx
@@ -1,0 +1,18 @@
+import ModalsContext from '@contexts/modals';
+import { Modals } from '@type/modals';
+import React, { useState } from 'react';
+
+interface ModalsProviderProps {
+  children: React.ReactNode;
+}
+
+const ModalsProvier = ({ children }: ModalsProviderProps) => {
+  const [modals, setModals] = useState<Modals>([]);
+  return (
+    <ModalsContext.Provider value={{ modals, setModals }}>
+      {children}
+    </ModalsContext.Provider>
+  );
+};
+
+export default ModalsProvier;

--- a/src/constants/modal-messages.ts
+++ b/src/constants/modal-messages.ts
@@ -1,17 +1,17 @@
 export const MODAL_MESSAGE = {
   CONFIRM: {
-    setMajor: '이 전공으로 선택할까요?',
-    editMajor: '이 전공으로 수정할까요?',
-    postSuggestion: '건의사항을 보내시겠어요?',
+    SET_MAJOR: '이 전공으로 선택할까요?',
+    EDIT_MAJOR: '이 전공으로 수정할까요?',
+    POST_SUGGESTION: '건의사항을 보내시겠어요?',
   },
   ALERT: {
-    overMapBounday: '앗! 지도의 영역을 벗어났어요',
-    overMapLevel: '앗! 더이상 지도를 축소할 수 없어요',
-    setMajor: '앗! 아직 전공을 알려주지 않았어요',
+    OVER_MAP_BOUNDARY: '앗! 지도의 영역을 벗어났어요',
+    OVER_MAP_LEVEL: '앗! 더이상 지도를 축소할 수 없어요',
+    SET_MAJOR: '앗! 아직 전공을 알려주지 않았어요',
   },
   SUCCEED: {
-    setMajor: '전공 선택 완료!',
-    editMajor: '전공 수정 완료!',
-    postSuggestion: '🙇‍♂️건의사항을 남겨 주셔서 정말 감사드립니다!🙇‍♂️',
+    SET_MAJOR: '전공 선택 완료!',
+    EDIT_MAJOR: '전공 수정 완료!',
+    POST_SUGGESTION: '🙇‍♂️건의사항을 남겨 주셔서 정말 감사드립니다!🙇‍♂️',
   },
 };

--- a/src/constants/modal-messages.ts
+++ b/src/constants/modal-messages.ts
@@ -1,0 +1,17 @@
+export const MODAL_MESSAGE = {
+  CONFIRM: {
+    setMajor: '이 전공으로 선택할까요?',
+    editMajor: '이 전공으로 수정할까요?',
+    postSuggestion: '건의사항을 보내시겠어요?',
+  },
+  ALERT: {
+    overMapBounday: '앗! 지도의 영역을 벗어났어요',
+    overMapLevel: '앗! 더이상 지도를 축소할 수 없어요',
+    setMajor: '앗! 아직 전공을 알려주지 않았어요',
+  },
+  SUCCEED: {
+    setMajor: '전공 선택 완료!',
+    editMajor: '전공 수정 완료!',
+    postSuggestion: '🙇‍♂️건의사항을 남겨 주셔서 정말 감사드립니다!🙇‍♂️',
+  },
+};

--- a/src/contexts/modals.ts
+++ b/src/contexts/modals.ts
@@ -1,0 +1,11 @@
+import { Modals } from '@type/modals';
+import { createContext } from 'react';
+
+interface ModalState {
+  modals: Modals;
+  setModals: React.Dispatch<React.SetStateAction<Modals>>;
+}
+
+const ModalsContext = createContext<ModalState | null>(null);
+
+export default ModalsContext;

--- a/src/hooks/useModals.ts
+++ b/src/hooks/useModals.ts
@@ -1,0 +1,44 @@
+import ModalsContext from '@contexts/modals';
+import {
+  ComponentProps,
+  FunctionComponent,
+  useCallback,
+  useContext,
+} from 'react';
+
+const useModals = () => {
+  const context = useContext(ModalsContext);
+  if (!context) {
+    throw new Error('MajorContext does not exists.');
+  }
+  const { modals, setModals } = context;
+
+  const openModal = useCallback(
+    <T extends FunctionComponent<any>>(
+      Component: T,
+      props: Omit<ComponentProps<T>, 'open'>,
+    ) => {
+      setModals((modals) => [
+        ...modals,
+        { Component, props: { ...props, open: true } },
+      ]);
+    },
+    [setModals],
+  );
+
+  const closeModal = useCallback(
+    <T extends FunctionComponent<any>>(Component: T) => {
+      setModals((modals) =>
+        modals.filter((modal) => modal.Component !== Component),
+      );
+    },
+    [setModals],
+  );
+  return {
+    modals,
+    openModal,
+    closeModal,
+  };
+};
+
+export default useModals;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,6 @@
 import MajorProvider from '@components/MajorProvider';
+import Modals from '@components/Modal/Modals';
+import ModalsProvider from '@components/ModalsProvider';
 import ThemeProvider from '@styles/ThemeProvider';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -16,7 +18,10 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <BrowserRouter>
       <ThemeProvider>
         <MajorProvider>
-          <App />
+          <ModalsProvider>
+            <Modals />
+            <App />
+          </ModalsProvider>
         </MajorProvider>
       </ThemeProvider>
     </BrowserRouter>

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -1,7 +1,6 @@
 import fetchAnnounceList from '@apis/Suspense/fetch-announce-list';
 import AnnounceList from '@components/Card/AnnounceCard/AnnounceList';
 import AnnounceCardSkeleton from '@components/Card/AnnounceCard/Skeleton';
-import MajorProvider from '@components/MajorProvider';
 import useMajor from '@hooks/useMajor';
 import { Suspense } from 'react';
 

--- a/src/pages/Home/Home.test.tsx
+++ b/src/pages/Home/Home.test.tsx
@@ -1,4 +1,5 @@
 import MajorProvider from '@components/MajorProvider';
+import ModalsProvier from '@components/ModalsProvider';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
@@ -9,7 +10,9 @@ describe('App 컴포넌트 테스트', () => {
   it('페이지에 공지사항 및 졸업요건 컴포넌트가 렌더링된다.', () => {
     render(
       <MajorProvider>
-        <Home />
+        <ModalsProvier>
+          <Home />
+        </ModalsProvier>
       </MajorProvider>,
       {
         wrapper: MemoryRouter,

--- a/src/pages/My/index.test.tsx
+++ b/src/pages/My/index.test.tsx
@@ -1,4 +1,7 @@
 import MajorProvider from '@components/MajorProvider';
+import SuggestionModal from '@components/Modal/SuggestionModal';
+import ModalsProvider from '@components/ModalsProvider';
+import useModals from '@hooks/useModals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
@@ -12,13 +15,29 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockRouterTo,
 }));
 
+jest.mock('@hooks/useModals', () => {
+  const modalsMock = {
+    modals: [],
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    default: () => modalsMock,
+  };
+});
+
 describe('마이 페이지 동작 테스트', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   it('건의사항 남기기 버튼 클릭 시 모달 렌더링 테스트', async () => {
     render(
       <MajorProvider>
-        <My />
+        <ModalsProvider>
+          <My />
+        </ModalsProvider>
       </MajorProvider>,
-      { wrapper: MemoryRouter },
     );
 
     const modalButton = screen.getByTestId('modal');
@@ -26,13 +45,19 @@ describe('마이 페이지 동작 테스트', () => {
       await userEvent.click(modalButton);
     });
 
-    expect(screen.getByText('건의사항')).toBeInTheDocument();
+    expect(useModals().openModal).toHaveBeenCalledWith(SuggestionModal, {
+      title: '건의사항',
+      buttonMessage: '보내기',
+      onClose: expect.any(Function),
+    });
   });
 
   it('전공수정 버튼 클릭 시 페이지 이동 테스트', async () => {
     render(
       <MajorProvider>
-        <My />
+        <ModalsProvider>
+          <My />
+        </ModalsProvider>
       </MajorProvider>,
       { wrapper: MemoryRouter },
     );

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -4,22 +4,26 @@ import SuggestionModal from '@components/Modal/SuggestionModal';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
+import useModals from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
-import { useState } from 'react';
 
 const My = () => {
   const { major } = useMajor();
   const { routerTo } = useRouter();
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const routerToMajorDecision = () => routerTo('/major-decision');
+  const { openModal, closeModal } = useModals();
 
-  const onClick = () => routerTo('/major-decision');
+  const handleSuggestionModal = () => {
+    openModal(SuggestionModal, {
+      title: '건의사항',
+      buttonMessage: '보내기',
+      onClose: () => closeModal(SuggestionModal),
+    });
+  };
 
   return (
     <>
-      {isModalOpen && (
-        <SuggestionModal onClose={() => setIsModalOpen((prev) => !prev)} />
-      )}
       <h1>마이페이지</h1>
       <Major>
         <span>전공</span>
@@ -33,18 +37,14 @@ const My = () => {
           <span>{major}</span>
           <Icon
             kind="edit"
-            onClick={onClick}
+            onClick={routerToMajorDecision}
             color={THEME.TEXT.GRAY}
             data-testid="edit"
           />
         </div>
       </Major>
-
       <Suggestion>
-        <Button
-          onClick={() => setIsModalOpen((prev) => !prev)}
-          data-testid="modal"
-        >
+        <Button data-testid="modal" onClick={handleSuggestionModal}>
           <Icon kind="suggest" color={THEME.TEXT.WHITE} />
           <span>건의사항 남기기</span>
         </Button>


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
* Closes : #105 
* 건의사항을 작성하고 사용자가 보내기 버튼을 누르기 전, 보낸 내용에 대해서 한번더 확인하는 모달을 구현했어요
* 개발이 진행됨에 따라, 모달을 사용하는 컴포넌트가 많아져서 각 컴포넌트가 모달의 상태를 가지고 있는게 비효율적이라고 판단했고 따라서 모달의 상태를 전역으로 빼기로 결정했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->
* 전역으로 관리 할 모달의 상태
  * boolean값을 사용해서 모달의 상태를 관리하려고 했으나, 이 방법을 사용하면 한 모달이 렌더링 되면 모든 모달이 렌더링 되는 문제가 발생해요
  * 전역으로 관리 하는 모달의 상태는 객체 배열이에요.
  ```typescript
   const 모달전역상태 = [
    {
      Component: // something....
      props: // something...
    },
    {
      //...
    }
  ]
  ```
  * modals - 객체 배열 / setModals: 객체 배열을 수정할 수 있는 함수

* 모달의 표준화
  * 앱 내부에서 사용하는 모달을 표준화 했어요
  * 크게 보면 경고, 확인, 건의사항전송 모달이 필요해서 각 컴포넌트를 추상화 하고 사용할 때 사용자에게 전달할 메세지와 함수를 주입할 수 있도록 했어요
 
* useModals 훅
  * 코드 
  ```typescript
  const useModals = () => {
      //...
      const openModal = useCallback(
      <T extends FunctionComponent<any>>(
        Component: T,
        props: Omit<ComponentProps<T>, 'open'>,
      ) => {
        setModals((modals) => [
          ...modals,
          { Component, props: { ...props, open: true } },
        ]);
      },
      [setModals],
    );
  
    const closeModal = useCallback(
      <T extends FunctionComponent<any>>(Component: T) => {
        setModals((modals) =>
          modals.filter((modal) => modal.Component !== Component),
        );
      },
      [setModals],
    );
    return {
      modals,
      openModal,
      closeModal,
    };
  };
  ```
  * 사용방법 : 모달을 열고 닫아야할 상황에 따라 `openModal`, `closeModal`을 호출해요
  ```typescript
  const handleMajorModal = () => {
    if (major) {
      routerToPath(path);
      return;
    }
    openModal(AlertModal, {
      message: MODAL_MESSAGE.ALERT.setMajor,
      buttonMessage: '전공선택하러 가기',
      iconKind: 'plus',
      onClose: () => closeModal(AlertModal),
      routerTo: () => {
        closeModal(AlertModal);
        routerToMajorDecision();
      },
    });
  };
  ```
* 변경된 테스트 코드
  * 커스텀 훅인 `useModals`를 호출하고 상황에 따라서, `openModals` 함수가 예상되는 인자와 함께 호출 되는지를 테스트 했어요

## 📷 스크린샷 (Optional)

https://github.com/hwinkr/algorithm/assets/68489467/4eb44e8b-4eb4-4686-9d0b-12d0c876e232

https://github.com/hwinkr/algorithm/assets/68489467/00e89e68-4575-4603-9c5e-5fc1eba1b6cc


