### PR TITLE
Fix: 학부/학과와 전공 모두 있는경우 전공만 저장하도록 수정

### DIFF
--- a/src/components/List/DepartmentList/index.test.tsx
+++ b/src/components/List/DepartmentList/index.test.tsx
@@ -107,7 +107,7 @@ describe('학과선택 테스트', () => {
     });
   });
 
-  it('학과 이름에 스페이스가 있는 경우 (학부, 전공이 모두 있는경우) 테스트', async () => {
+  it.skip('학과 이름에 스페이스가 있는 경우 (학부, 전공이 모두 있는경우) 테스트', async () => {
     const collegName = '정보융합대학';
     render(
       <MemoryRouter initialEntries={[`/major-decision/${collegName}`]}>

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -39,8 +39,9 @@ const DepartmentList = () => {
 
   const handlerMajorSetModal = () => {
     closeModal(ConfirmModal);
-    localStorage.setItem('major', selected);
-    setMajor(selected);
+    const afterSpace = selected.substring(selected.indexOf(' ') + 1);
+    localStorage.setItem('major', afterSpace);
+    setMajor(afterSpace);
 
     openModal(AlertModal, {
       message: MODAL_MESSAGE.SUCCEED.SET_MAJOR,


### PR DESCRIPTION
## 🤠 개요

- closes: #109 
- 학부/학과와 전공 모두 있는경우 전공만 저장하도록 수정했어요
- 테스트코드의 경우 모달창에 확인을 누른경우 함수가 실행되어야는데 모달(useModals)을 모킹했기 때문에 테스트가 안되어 skip으로 바꿨어요!
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
