### PR TITLE
Feat/#112: 공지사항 페이지에서 학교, 학과 공지사항을 분리해서 보여줄 수 있는 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => {
       <Header />
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/announcement" element={<Announcement />} />
+        <Route path="/announcement/*" element={<Announcement />} />
         <Route path="/my" element={<My />} />
         <Route path="/map" element={<Map />} />
         <Route path="/major-decision/*" element={<MajorDecision />} />

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 import { THEME } from '@styles/ThemeProvider/theme';
-import { ReactNode } from 'react';
+import { ButtonHTMLAttributes, ReactNode } from 'react';
 
-interface ButtonProps {
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: ReactNode;
   onClick?: React.MouseEventHandler<HTMLElement>;
   disabled?: boolean;

--- a/src/components/Card/InformCard/index.test.tsx
+++ b/src/components/Card/InformCard/index.test.tsx
@@ -97,6 +97,7 @@ describe('InformCard 컴포넌트 테스트', () => {
             icon={INFORM_CARD['ANNOUNCEMENT'].icon}
             title={INFORM_CARD['ANNOUNCEMENT'].title}
             onClick={INFORM_CARD['ANNOUNCEMENT'].onClick}
+            majorRequired={true}
           />
         </ModalsProvider>
       </MajorContext.Provider>,
@@ -121,6 +122,7 @@ describe('InformCard 컴포넌트 테스트', () => {
             icon={INFORM_CARD['ANNOUNCEMENT'].icon}
             title={INFORM_CARD['ANNOUNCEMENT'].title}
             onClick={INFORM_CARD['ANNOUNCEMENT'].onClick}
+            majorRequired={true}
           />
         </ModalsProvider>
       </MajorContext.Provider>,
@@ -151,6 +153,7 @@ describe('InformCard 컴포넌트 테스트', () => {
             icon={INFORM_CARD['GRADUATION'].icon}
             title={INFORM_CARD['GRADUATION'].title}
             onClick={INFORM_CARD['GRADUATION'].onClick}
+            majorRequired={true}
           />
         </ModalsProvider>
       </MajorContext.Provider>,

--- a/src/components/Card/InformCard/index.tsx
+++ b/src/components/Card/InformCard/index.tsx
@@ -15,17 +15,23 @@ import { setSize } from '@utils/styles/size';
 interface InformCardProps {
   icon: IconKind & ('school' | 'notification');
   title: string;
+  majorRequired: boolean;
   onClick: () => void;
 }
 
-const InformCard = ({ icon, title, onClick }: InformCardProps) => {
+const InformCard = ({
+  icon,
+  title,
+  majorRequired,
+  onClick,
+}: InformCardProps) => {
   const { major } = useMajor();
   const { routerTo } = useRouter();
   const routerToMajorDecision = () => routerTo('/major-decision');
   const { openModal, closeModal } = useModals();
 
   const handleMajorModal = () => {
-    if (major) {
+    if (!majorRequired || major) {
       onClick();
       return;
     }

--- a/src/mocks/handlers/announceHandlers.ts
+++ b/src/mocks/handlers/announceHandlers.ts
@@ -4,7 +4,29 @@ import { RequestHandler, rest } from 'msw';
 export const announceHandlers: RequestHandler[] = [
   rest.get(`${SERVER_URL}/api/announcement`, (req, res, ctx) => {
     const query = req.url.searchParams;
-    if (query.get('major') === '컴퓨터인공지능학부') {
+    if (query.get('major') === 'undefined') {
+      return res(
+        ctx.status(200),
+        ctx.json([
+          {
+            title:
+              '★대학원생 취·창업 역량 강화 프로그램★ 4단계 BK21 대학원혁신지원사업',
+            path: 'https://www.pknu.ac.kr/main/163?action=view&no=711472&cd=10001',
+            date: '2023-07-17',
+          },
+          {
+            title: '2023-2학기 재(복)학생, 재입학생 등록금 납부 안내',
+            path: 'https://www.pknu.ac.kr/main/163?action=view&no=711433&cd=10001',
+            date: '2023-07-14',
+          },
+          {
+            title: '2023-2학기 재(복)학생 등록금 분할납부 신청 안내',
+            path: 'https://www.pknu.ac.kr/main/163?action=view&no=711431&cd=10001',
+            date: '2023-07-14',
+          },
+        ]),
+      );
+    } else if (query.get('major') === '컴퓨터인공지능학부') {
       return res(
         ctx.status(200),
         ctx.json([

--- a/src/mocks/handlers/announceHandlers.ts
+++ b/src/mocks/handlers/announceHandlers.ts
@@ -11,18 +11,18 @@ export const announceHandlers: RequestHandler[] = [
           {
             title:
               '★대학원생 취·창업 역량 강화 프로그램★ 4단계 BK21 대학원혁신지원사업',
-            path: 'https://www.pknu.ac.kr/main/163?action=view&no=711472&cd=10001',
-            date: '2023-07-17',
+            link: 'https://www.pknu.ac.kr/main/163?action=view&no=711472&cd=10001',
+            uploadDate: '2023-07-17',
           },
           {
             title: '2023-2학기 재(복)학생, 재입학생 등록금 납부 안내',
-            path: 'https://www.pknu.ac.kr/main/163?action=view&no=711433&cd=10001',
-            date: '2023-07-14',
+            link: 'https://www.pknu.ac.kr/main/163?action=view&no=711433&cd=10001',
+            uploadDate: '2023-07-14',
           },
           {
             title: '2023-2학기 재(복)학생 등록금 분할납부 신청 안내',
-            path: 'https://www.pknu.ac.kr/main/163?action=view&no=711431&cd=10001',
-            date: '2023-07-14',
+            link: 'https://www.pknu.ac.kr/main/163?action=view&no=711431&cd=10001',
+            uploadDate: '2023-07-14',
           },
         ]),
       );
@@ -32,19 +32,19 @@ export const announceHandlers: RequestHandler[] = [
         ctx.json([
           {
             title: '2023 정보융합대학 프로그래밍 경진대회 개최 (5/17)',
-            path: 'https://ce.pknu.ac.kr/ce/1814?action=view&no=9934358',
-            date: '2023-04-27',
+            link: 'https://ce.pknu.ac.kr/ce/1814?action=view&no=9934358',
+            uploadDate: '2023-04-27',
           },
           {
             title: '★ (05/01부터 적용) 출석 인정 신청 방법 안내 ★',
-            path: 'https://ce.pknu.ac.kr/ce/1814?action=view&no=9934257',
-            date: '2023-04-26	',
+            link: 'https://ce.pknu.ac.kr/ce/1814?action=view&no=9934257',
+            uploadDate: '2023-04-26	',
           },
           {
             title:
               '2023-1학기 (재)부경대학교발전기금재단 정효택장학생 선발 안내(5/8~5/11)',
-            path: 'https://ce.pknu.ac.kr/ce/1814?action=view&no=9934104',
-            date: '2023-04-20',
+            link: 'https://ce.pknu.ac.kr/ce/1814?action=view&no=9934104',
+            uploadDate: '2023-04-20',
           },
         ]),
       );

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -15,8 +15,8 @@ const Announcement = () => {
   const { major } = useMajor();
   const { routerTo } = useRouter();
   const { openModal, closeModal } = useModals();
-  const announceKeyword = decodeURI(window.location.pathname.split('/')[2]);
   const routerToMajorDecision = () => routerTo('/major-decision');
+  const announceKeyword = decodeURI(window.location.pathname.split('/')[2]);
 
   const handleMajorAnnouncements = () => {
     if (!major) {
@@ -35,6 +35,8 @@ const Announcement = () => {
     routerTo(`${major}`);
   };
 
+  const isKeywordUndefined = () => announceKeyword === 'undefined';
+
   return (
     <>
       <div
@@ -45,8 +47,11 @@ const Announcement = () => {
         <Button
           onClick={() => routerTo('')}
           css={css`
-            background-color: ${announceKeyword !== 'undefined' &&
-            THEME.BUTTON.GRAY};
+            border-bottom: ${isKeywordUndefined() &&
+            `3px solid ${THEME.PRIMARY}`};
+            border-radius: 0px;
+            background-color: ${THEME.TEXT.WHITE};
+            color: ${isKeywordUndefined() ? THEME.PRIMARY : THEME.TEXT.BLACK};
           `}
         >
           학교 공지사항
@@ -54,8 +59,11 @@ const Announcement = () => {
         <Button
           onClick={() => handleMajorAnnouncements()}
           css={css`
-            background-color: ${announceKeyword === 'undefined' &&
-            THEME.BUTTON.GRAY};
+            border-bottom: ${!isKeywordUndefined() &&
+            `3px solid ${THEME.PRIMARY}`};
+            border-radius: 0px;
+            background-color: ${THEME.TEXT.WHITE};
+            color: ${isKeywordUndefined() ? THEME.TEXT.BLACK : THEME.PRIMARY};
           `}
         >
           학과 공지사항

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -1,16 +1,68 @@
 import fetchAnnounceList from '@apis/Suspense/fetch-announce-list';
+import Button from '@components/Button';
 import AnnounceList from '@components/Card/AnnounceCard/AnnounceList';
 import AnnounceCardSkeleton from '@components/Card/AnnounceCard/Skeleton';
+import AlertModal from '@components/Modal/AlertModal';
+import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { css } from '@emotion/react';
 import useMajor from '@hooks/useMajor';
+import useModals from '@hooks/useModals';
+import useRouter from '@hooks/useRouter';
+import { THEME } from '@styles/ThemeProvider/theme';
 import { Suspense } from 'react';
 
 const Announcement = () => {
   const { major } = useMajor();
+  const { routerTo } = useRouter();
+  const { openModal, closeModal } = useModals();
+  const announceKeyword = decodeURI(window.location.pathname.split('/')[2]);
+  const routerToMajorDecision = () => routerTo('/major-decision');
+
+  const handleMajorAnnouncements = () => {
+    if (!major) {
+      openModal(AlertModal, {
+        message: MODAL_MESSAGE.ALERT.SET_MAJOR,
+        buttonMessage: '전공선택하러 가기',
+        iconKind: 'plus',
+        onClose: () => closeModal(AlertModal),
+        routerTo: () => {
+          closeModal(AlertModal);
+          routerToMajorDecision();
+        },
+      });
+      return;
+    }
+    routerTo(`${major}`);
+  };
 
   return (
     <>
+      <div
+        css={css`
+          display: flex;
+        `}
+      >
+        <Button
+          onClick={() => routerTo('')}
+          css={css`
+            background-color: ${announceKeyword !== 'undefined' &&
+            THEME.BUTTON.GRAY};
+          `}
+        >
+          학교 공지사항
+        </Button>
+        <Button
+          onClick={() => handleMajorAnnouncements()}
+          css={css`
+            background-color: ${announceKeyword === 'undefined' &&
+            THEME.BUTTON.GRAY};
+          `}
+        >
+          학과 공지사항
+        </Button>
+      </div>
       <Suspense fallback={<AnnounceCardSkeleton length={30} />}>
-        <AnnounceList resource={fetchAnnounceList(major)} />
+        <AnnounceList resource={fetchAnnounceList(announceKeyword)} />
       </Suspense>
     </>
   );

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -34,11 +34,13 @@ const Home = () => {
         <InformCard
           icon="notification"
           title="공지사항"
+          majorRequired={false}
           onClick={() => routerTo('/announcement')}
         />
         <InformCard
           icon="school"
           title="졸업요건"
+          majorRequired={true}
           onClick={() => routerToGraduationRequired()}
         />
       </div>


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
* 공지사항 페이지 내부에서 학교, 학과 공지사항을 분리해서 보여줄 수 있도록 했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->
* `announceKeyword`를 사용해서, 비동기 데이터를 가져와요
  * 이렇게 한 이유는 state 사용할 경우 새로고침할 경우 문제가 생기고(앱이라서 새로고침 할 일은 없겠지만,,,) 
  * `setState` 호출로 인해서 불필요한 리렌더링도 발생할 수 있기 때문에, URL을 파싱하기로 했어요.
* 현재 사용자가 보고 있는 공지사항을 강조해주기 위해서 기존에 사용중이던 `Button` 컴포넌트에 스타일을 외부에서 주입할 수 있도록 변경했어요.
  * 프로토타입을 작성할 때, 피그마에서는 버튼의 배경색이 아닌 css `border`의 `bottom-line`을 통해서 강조했어요.
  * 하지만, 개발을 시작하고 나서 버튼의 배경색을 GREEN으로 고정했고 고정된 배경색을 사용중인 컴포넌트도 너무 많아서 지금 배경색을 외부에서 주입하도록 변경하기에는 오버헤드가 너무 클 것 같다는 판단을 했어요.
  * 따라서, 버튼의 배경색을 변경해야 하는 경우에만 외부에서 주입하도록 하기 위해서`ButtonHTMLAttributes<HTMLButtonElement>`이 타입을 확장해서 Button 컴포넌트의 prop을 재정의 했어요!
* informCard 컴포넌트에 추가된 `majorRequired` prop
  * 학교 공지사항은 전공이 선택되지 않아도 보여주기로 결정했고, 따라서 공지사항 페이지 자체는 전공 선택되지 않아도 방문할 수 있도록 해야 했어요.
  * 따라서, 졸업요건 카드만 전공을 선택해야 사용할 수 있도록 해야 했는데 전공이 필요한지 아닌지를 외부에서 주입하기로 결정했어요
## 📷 스크린샷 (Optional)
<img width="488" alt="Screenshot 2023-07-31 at 22 54 52" src="https://github.com/hwinkr/algorithm/assets/68489467/19b6a86b-1f5b-4c23-b179-bf4d89391d0e">
<img width="490" alt="Screenshot 2023-07-31 at 22 54 58" src="https://github.com/hwinkr/algorithm/assets/68489467/8d456b8c-3abe-4aa3-9d65-5b50d09bd3c9">

