### PR TITLE
Style/#113: 단과대/학과 선택 UI 개선

### DIFF
--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -38,6 +38,7 @@ interface IconProps {
   kind: IconKind;
   onClick?: () => void;
   color?: string;
+  size?: string;
 }
 
 const Icon = ({ kind, ...props }: IconProps) => {

--- a/src/components/List/CollegeList/index.tsx
+++ b/src/components/List/CollegeList/index.tsx
@@ -1,7 +1,9 @@
 import http from '@apis/http';
 import Icon from '@components/Icon';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useRouter from '@hooks/useRouter';
+import { THEME } from '@styles/ThemeProvider/theme';
 import React, { useState, useEffect } from 'react';
 
 const CollegeList = () => {
@@ -18,8 +20,6 @@ const CollegeList = () => {
   };
 
   const onClick: React.MouseEventHandler<HTMLElement> = (e) => {
-    if (e.target !== e.currentTarget) return;
-
     const collegeName = e.currentTarget.textContent;
 
     if (collegeName === null) routerTo('/major-decision');
@@ -30,12 +30,20 @@ const CollegeList = () => {
     <ListContainer>
       <Title>단과대 선택하기</Title>
       {collegeList.map((college) => (
-        <ListWrapper key={college} onClick={onClick}>
-          {college}
-          <IconWrapper>
-            <Icon kind="right" />
-          </IconWrapper>
-        </ListWrapper>
+        <div
+          key={college}
+          css={css`
+            width: 100%;
+          `}
+          onClick={onClick}
+        >
+          <ListWrapper>
+            {college}
+            <IconWrapper>
+              <Icon kind="right" />
+            </IconWrapper>
+          </ListWrapper>
+        </div>
       ))}
     </ListContainer>
   ) : (
@@ -49,7 +57,10 @@ const ListContainer = styled.div`
 `;
 
 const ListWrapper = styled.div`
-  padding: 3% 3% 3% 1%;
+  padding: 8% 6% 8% 6%;
+  width: 80%;
+  margin: 0 auto;
+  border-bottom: 1px solid ${THEME.BUTTON.GRAY};
 `;
 
 const IconWrapper = styled.div`
@@ -57,7 +68,9 @@ const IconWrapper = styled.div`
 `;
 
 const Title = styled.h2`
-  font-size: 2rem;
+  font-size: 1.5rem;
+  margin-bottom: 3%;
+  padding-left: 5%;
 `;
 
 export default CollegeList;

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -4,6 +4,7 @@ import Icon from '@components/Icon';
 import AlertModal from '@components/Modal/AlertModal';
 import ConfirmModal from '@components/Modal/ConfirmModal';
 import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
 import useModals from '@hooks/useModals';
@@ -69,15 +70,22 @@ const DepartmentList = () => {
     <ListContainer>
       <Title>학과 선택하기</Title>
       {departmentList.map((department) => (
-        <ListWrapper key={department} onClick={onClick}>
-          {department}
-          <IconWrapper>
+        <div
+          key={department}
+          css={css`
+            width: 100%;
+          `}
+          onClick={onClick}
+        >
+          <ListWrapper>
+            {department}
             <Icon
               kind={selected === department ? 'checkedRadio' : 'uncheckedRadio'}
               color={selected === department ? THEME.PRIMARY : THEME.TEXT.GRAY}
+              size="24"
             />
-          </IconWrapper>
-        </ListWrapper>
+          </ListWrapper>
+        </div>
       ))}
       <ButtonContainer>
         <Button disabled={buttonDisable} onClick={handleMajorConfirmModal}>
@@ -92,7 +100,10 @@ const DepartmentList = () => {
 
 const ButtonContainer = styled.div`
   position: fixed;
-  bottom: 100px;
+  bottom: 7%;
+  z-index: 3;
+  width: 80%;
+  max-width: 480px;
   left: 50%;
   transform: translate(-50%, -50%);
 
@@ -109,18 +120,24 @@ const ButtonContainer = styled.div`
 const ListContainer = styled.div`
   padding-top: 2%;
   padding-left: 2%;
+  padding-bottom: 15%;
+  overflow: auto;
 `;
 
 const Title = styled.h2`
-  font-size: 2rem;
+  font-size: 1.5rem;
+  margin-bottom: 3%;
+  padding-left: 5%;
 `;
 
 const ListWrapper = styled.div`
-  padding: 3% 3% 3% 1%;
-`;
-
-const IconWrapper = styled.div`
-  float: right;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 80%;
+  margin: 0 auto;
+  border-bottom: 1px solid ${THEME.BUTTON.GRAY};
+  padding: 8% 6% 8% 6%;
 `;
 
 export default DepartmentList;


### PR DESCRIPTION
## 🤠 개요

- closes: #113
- 단과대/학과 선택 UI 개선했어요
- #115에 대응해서 만들었기에 모두 합쳐보고 추가로 수정하는게 좋을거 같아요!
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
- #115에 대응해서 만들었기에 현재 이미지에 Footer쪽에 부자연스러운 부분이 있어요
- 버튼이 여러개 클릭된거는 학과 이름이 같아서 div 키 값이 같아서 여러개 선택되어 있어요..
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/f4c53225-7b40-4d2e-9af1-1113537a182e)
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/de3fc730-b630-4d89-8fb1-99b52b2ba168)
