### PR TITLE
Fix: 헤더 padding 크기 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,5 +33,5 @@ const Container = styled.div`
 `;
 
 const Body = styled.div`
-  padding: 17% 0 17% 0;
+  padding: 12.5% 0 17% 0;
 `;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -34,7 +34,7 @@ const HeaderContainer = styled.div`
   display: flex;
   justify-content: center;
   max-width: 480px;
-  height: 8%;
+  height: 6%;
   background-color: ${THEME.TEXT.WHITE};
   z-index: 2;
 `;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -9,7 +9,7 @@ const Header = () => {
     <HeaderContainer>
       <HeaderWrapper>
         <Icon kind="arrowBack" onClick={goBack} />
-        <Logo onClick={() => routerTo('/')}>Logo</Logo>
+        <Logo onClick={() => routerTo('/')}>burimi</Logo>
         <Icon kind="menu" />
       </HeaderWrapper>
     </HeaderContainer>


### PR DESCRIPTION
## 🤠 개요

- closes: #130 
- 헤더 크기를 줄였어요!
- 헤더 중간에 LOGO에서 BURIMI 로 바꿨어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
--before--
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/6a239aea-e018-4ce3-8340-1388642ff549)

--after--
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/45b4cd42-2ddf-4328-a012-b636e58b07e9)