### PR TITLE
Fix: 학과 선택하는 버튼 아래로 배치

### DIFF
--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -69,24 +69,34 @@ const DepartmentList = () => {
   return departmentList ? (
     <ListContainer>
       <Title>학과 선택하기</Title>
-      {departmentList.map((department) => (
-        <div
-          key={department}
-          css={css`
-            width: 100%;
-          `}
-          onClick={onClick}
-        >
-          <ListWrapper>
-            {department}
-            <Icon
-              kind={selected === department ? 'checkedRadio' : 'uncheckedRadio'}
-              color={selected === department ? THEME.PRIMARY : THEME.TEXT.GRAY}
-              size="24"
-            />
-          </ListWrapper>
-        </div>
-      ))}
+      <div
+        css={css`
+          height: 60vh;
+        `}
+      >
+        {departmentList.map((department) => (
+          <div
+            key={department}
+            css={css`
+              width: 100%;
+            `}
+            onClick={onClick}
+          >
+            <ListWrapper>
+              {department}
+              <Icon
+                kind={
+                  selected === department ? 'checkedRadio' : 'uncheckedRadio'
+                }
+                color={
+                  selected === department ? THEME.PRIMARY : THEME.TEXT.GRAY
+                }
+                size="24"
+              />
+            </ListWrapper>
+          </div>
+        ))}
+      </div>
       <ButtonContainer>
         <Button disabled={buttonDisable} onClick={handleMajorConfirmModal}>
           선택완료
@@ -100,7 +110,7 @@ const DepartmentList = () => {
 
 const ButtonContainer = styled.div`
   position: fixed;
-  bottom: 7%;
+  bottom: 4%;
   z-index: 3;
   width: 80%;
   max-width: 480px;


### PR DESCRIPTION
## 🤠 개요

- closes: #132 
- 학과 선택하는 버튼 아래로 배치했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
아래와 같이 버튼까지 콘텐츠가 안내려가도록 수정했어요!
<img width="500" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/a6bfc038-e25c-4468-9c46-b322b5444efc">
