### PR TITLE
Fix: 모바일에서 확대 안되도록 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
       sizes="152x152"
     />
     <link rel="manifest" href="manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>


### PR DESCRIPTION
## 🤠 개요

- closes: #134 
- 모바일에서 확대 안되도록 수정했어요
- 다만 카카오맵에서는 확대 및 축소가 가능한것을 확인했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
