### PR TITLE
Fix: 헤더, 푸터 높이 단위 vh 로 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,5 +33,5 @@ const Container = styled.div`
 `;
 
 const Body = styled.div`
-  padding: 12.5% 0 17% 0;
+  padding: 8.5vh 0 8.5vh 0;
 `;

--- a/src/components/FooterTab/index.tsx
+++ b/src/components/FooterTab/index.tsx
@@ -49,7 +49,7 @@ const Footer = styled.div`
   transform: translateX(-50%);
   width: 100%;
 
-  height: 8%;
+  height: 8vh;
 
   display: flex;
   justify-content: space-around;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -34,7 +34,7 @@ const HeaderContainer = styled.div`
   display: flex;
   justify-content: center;
   max-width: 480px;
-  height: 6%;
+  height: 8vh;
   background-color: ${THEME.TEXT.WHITE};
   z-index: 2;
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #138 
- 헤더, 푸터 높이 단위 vh 로 변경했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
