### PR TITLE
Feat/#143: 헤더, 푸터 제외한 컴포넌트 높이 고정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { Routes, Route } from 'react-router-dom';
 
 const App = () => {
   return (
-    <Container>
+    <>
       <Header />
       <Body>
         <Routes>
@@ -22,16 +22,13 @@ const App = () => {
         </Routes>
       </Body>
       <FooterTab />
-    </Container>
+    </>
   );
 };
 
 export default App;
 
-const Container = styled.div`
-  height: 100vh;
-`;
-
 const Body = styled.div`
-  padding: 8.5vh 0 8.5vh 0;
+  height: calc(100vh - 16vh);
+  padding: 8vh 0 8vh 0;
 `;

--- a/src/pages/Map/MapboundaryObserver.tsx
+++ b/src/pages/Map/MapboundaryObserver.tsx
@@ -27,7 +27,7 @@ const MapboundaryObserver = ({ map, centerLocation }: MapBounds) => {
         map.setLevel(4);
         map.setCenter(centerLocation);
         openModal(AlertModal, {
-          message: MODAL_MESSAGE.ALERT.OVER_MAP_LEVEL,
+          message: MODAL_MESSAGE.ALERT.OVER_MAP_BOUNDARY,
           buttonMessage: '닫기',
           onClose: () => closeModal(AlertModal),
         });

--- a/src/pages/Map/index.tsx
+++ b/src/pages/Map/index.tsx
@@ -32,7 +32,7 @@ const Map = () => {
   return (
     <div
       css={css`
-        height: calc(90vh - 40px);
+        height: calc(100vh - 16vh);
         display: flex;
         justify-content: center;
         align-items: center;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
* 헤더, 푸터 제외한 컴포넌트 높이 고정했어요
* 추가로, 지도 페이지에서 지도 영역을 벗어났을 때 메세지도 수정했어요.

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
