### PR TITLE
Fix: 외부링크 이동 시 인앱 브라우저가 아닌 외부 브라우저로 열리도록 수정

### DIFF
--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -15,7 +15,7 @@ const AnnounceCard = ({
   pinned = false,
 }: AnnounceCardProps) => {
   const onClick = () => {
-    window.location.href = link;
+    window.open(link, '_blank');
   };
   return (
     <Card onClick={onClick} data-testid="card">


### PR DESCRIPTION
## 🤠 개요

- closes: #149 
- 외부링크 이동 시 인앱 브라우저가 아닌 외부 브라우저로 열리도록 수정했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
