### PR TITLE
Fix: Body의 높이 설정 안하는걸로 롤백

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,5 @@ const App = () => {
 export default App;
 
 const Body = styled.div`
-  height: calc(100vh - 16vh);
-  padding: 8vh 0 8vh 0;
+  padding: 8.5vh 0 8.5vh 0;
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #156 
- Body의 높이 설정 안하는걸로 롤백했어요
- header, footer 의 높이는 8vh 이고 콘텐츠의 상단 하단 공백을 여유분을 추가하여 8.5vh 로 padding 설정했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
