### PR TITLE
style: 카드 모양 변경

### DIFF
--- a/src/components/Card/InformCard/index.tsx
+++ b/src/components/Card/InformCard/index.tsx
@@ -8,7 +8,6 @@ import useModals from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { IconKind } from '@type/styles/icon';
-import { setSize } from '@utils/styles/size';
 
 // TODO: InformCard 컴포넌트 Props 및 로직 수정
 
@@ -50,18 +49,26 @@ const InformCard = ({
   return (
     <>
       <Card data-testid="card" icon={icon} onClick={handleMajorModal}>
-        <Icon
-          kind={icon}
-          color={icon === 'school' ? THEME.TEXT.GRAY : THEME.TEXT.WHITE}
-        />
-        <span
+        <div
           css={css`
-            font-size: 18px;
-            font-weight: bold;
+            display: flex;
+            align-items: center;
           `}
         >
-          {title}
-        </span>
+          <Icon
+            kind={icon}
+            color={icon === 'school' ? THEME.TEXT.GRAY : THEME.TEXT.WHITE}
+          />
+          <span
+            css={css`
+              font-size: 18px;
+              font-weight: bold;
+              margin-left: 10px;
+            `}
+          >
+            {title}
+          </span>
+        </div>
         <span
           css={css`
             font-size: 16px;
@@ -84,16 +91,19 @@ const Card = styled.div<CardProps>(({ icon }) => {
     display: 'flex',
     flexDirection: 'column',
     padding: '15px',
+    marginBottom: '5%',
 
     borderRadius: '15px',
 
     backgroundColor: icon === 'school' ? THEME.BACKGROUND : THEME.PRIMARY,
     color: icon === 'school' ? THEME.TEXT.GRAY : THEME.TEXT.WHITE,
+    boxShadow: 'rgba(149, 157, 165, 0.2) 0px 8px 24px',
+
+    height: '90px',
 
     '& > svg': {
       margin: '10px 0',
     },
-    ...setSize(200, 150),
     cursor: 'pointer',
   };
 });

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -49,4 +49,5 @@ const Container = styled.div`
   width: 85%;
   text-aligb: center;
   margin: 0 auto;
+  padding-top: 5%;
 `;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,6 +1,6 @@
 import http from '@apis/http';
 import InformCard from '@components/Card/InformCard';
-import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
 import useRouter from '@hooks/useRouter';
 import { useEffect, useState } from 'react';
@@ -24,28 +24,29 @@ const Home = () => {
   }, [major]);
 
   return (
-    <>
-      <div
-        css={css`
-          display: flex;
-          justify-content: center;
-        `}
-      >
-        <InformCard
-          icon="notification"
-          title="공지사항"
-          majorRequired={false}
-          onClick={() => routerTo('/announcement')}
-        />
-        <InformCard
-          icon="school"
-          title="졸업요건"
-          majorRequired={true}
-          onClick={() => routerToGraduationRequired()}
-        />
-      </div>
-    </>
+    <Container>
+      <InformCard
+        icon="notification"
+        title="공지사항"
+        majorRequired={false}
+        onClick={() => routerTo('/announcement')}
+      />
+      <InformCard
+        icon="school"
+        title="졸업요건"
+        majorRequired={true}
+        onClick={() => routerToGraduationRequired()}
+      />
+    </Container>
   );
 };
 
 export default Home;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 85%;
+  text-aligb: center;
+  margin: 0 auto;
+`;


### PR DESCRIPTION
## 🤠 개요

- closes: #155 
- 메인 화면의 카드 모양을 변경했어요
- 메인 화면에 학교, 학과 공지사항을 따로 보여주는건 고민을 조금 해봐야할 거 같아서 아직 남겨뒀어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="580" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/0daba02e-360a-4974-b4be-a19e0c3f089d">
