### PR TITLE
Style/#159: 헤더 푸터 그림자 추가

### DIFF
--- a/src/components/Card/InformCard/index.tsx
+++ b/src/components/Card/InformCard/index.tsx
@@ -8,7 +8,6 @@ import useModals from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { IconKind } from '@type/styles/icon';
-import { setSize } from '@utils/styles/size';
 
 // TODO: InformCard 컴포넌트 Props 및 로직 수정
 
@@ -50,18 +49,26 @@ const InformCard = ({
   return (
     <>
       <Card data-testid="card" icon={icon} onClick={handleMajorModal}>
-        <Icon
-          kind={icon}
-          color={icon === 'school' ? THEME.TEXT.GRAY : THEME.TEXT.WHITE}
-        />
-        <span
+        <div
           css={css`
-            font-size: 18px;
-            font-weight: bold;
+            display: flex;
+            align-items: center;
           `}
         >
-          {title}
-        </span>
+          <Icon
+            kind={icon}
+            color={icon === 'school' ? THEME.TEXT.GRAY : THEME.TEXT.WHITE}
+          />
+          <span
+            css={css`
+              font-size: 18px;
+              font-weight: bold;
+              margin-left: 10px;
+            `}
+          >
+            {title}
+          </span>
+        </div>
         <span
           css={css`
             font-size: 16px;
@@ -84,16 +91,19 @@ const Card = styled.div<CardProps>(({ icon }) => {
     display: 'flex',
     flexDirection: 'column',
     padding: '15px',
+    marginBottom: '5%',
 
     borderRadius: '15px',
 
     backgroundColor: icon === 'school' ? THEME.BACKGROUND : THEME.PRIMARY,
     color: icon === 'school' ? THEME.TEXT.GRAY : THEME.TEXT.WHITE,
+    boxShadow: 'rgba(149, 157, 165, 0.2) 0px 8px 24px',
+
+    height: '90px',
 
     '& > svg': {
       margin: '10px 0',
     },
-    ...setSize(200, 150),
     cursor: 'pointer',
   };
 });

--- a/src/components/FooterTab/index.tsx
+++ b/src/components/FooterTab/index.tsx
@@ -56,6 +56,7 @@ const Footer = styled.div`
   align-items: center;
   z-index: 2;
   background-color: ${THEME.TEXT.WHITE};
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
 `;
 
 const IconContainer = styled.div`

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -37,6 +37,7 @@ const HeaderContainer = styled.div`
   height: 8vh;
   background-color: ${THEME.TEXT.WHITE};
   z-index: 2;
+  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
 `;
 
 const HeaderWrapper = styled.div`

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,6 +1,6 @@
 import http from '@apis/http';
 import InformCard from '@components/Card/InformCard';
-import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
 import useRouter from '@hooks/useRouter';
 import { useEffect, useState } from 'react';
@@ -24,28 +24,29 @@ const Home = () => {
   }, [major]);
 
   return (
-    <>
-      <div
-        css={css`
-          display: flex;
-          justify-content: center;
-        `}
-      >
-        <InformCard
-          icon="notification"
-          title="공지사항"
-          majorRequired={false}
-          onClick={() => routerTo('/announcement')}
-        />
-        <InformCard
-          icon="school"
-          title="졸업요건"
-          majorRequired={true}
-          onClick={() => routerToGraduationRequired()}
-        />
-      </div>
-    </>
+    <Container>
+      <InformCard
+        icon="notification"
+        title="공지사항"
+        majorRequired={false}
+        onClick={() => routerTo('/announcement')}
+      />
+      <InformCard
+        icon="school"
+        title="졸업요건"
+        majorRequired={true}
+        onClick={() => routerToGraduationRequired()}
+      />
+    </Container>
   );
 };
 
 export default Home;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 85%;
+  text-aligb: center;
+  margin: 0 auto;
+`;

--- a/src/styles/Global/index.tsx
+++ b/src/styles/Global/index.tsx
@@ -108,6 +108,7 @@ const resetCss = css`
     max-width: 480px;
     margin: 0 auto;
     min-height: 100vh;
+    background-color: #fffef9;
   }
   ol,
   ul {


### PR DESCRIPTION
## 🤠 개요

- closes: #159 
- 헤더 푸터 그림자 추가했어요
- 배경색을 완전 흰색이 아니라 노란 흰색으로 바꿨어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
![IMG_78CB6282EB22-1](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/0fc880dd-404a-4770-8641-1340bb586793)
