### PR TITLE
Feat/#161: 알림 받을 수 있도록 기능 추가 & 마이페이지 디자인 개선

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,61 @@
+{
+  "name": "부림이",
+  "short_name": "부림이",
+  "start_url": "/",
+  "display": "fullscreen",
+  "background_color": "#ffffff",
+  "lang": "en",
+  "scope": "/",
+  "orientation": "portrait",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "icons/icon-48x48.png",
+      "sizes": "48x48",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-128x128.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-152x152.png",
+      "sizes": "152x152",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-384x384.png",
+      "sizes": "384x384",
+      "type": "image/png"
+    },
+    { "src": "icons/icon-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -12,3 +12,11 @@ self.addEventListener('activate', (e) => {
 self.addEventListener('fetch', (e) => {
   console.log('[Service Worker] fetched resource ' + e.request.url);
 });
+
+self.addEventListener('push', (e) => {
+  const data = e.data.json();
+  self.registration.showNotification(data.title, {
+    body: data.body,
+    icon: data.icon,
+  });
+});

--- a/src/components/Button/Toggle/index.tsx
+++ b/src/components/Button/Toggle/index.tsx
@@ -5,18 +5,20 @@ import { MouseEventHandler } from 'react';
 interface Props {
   isOn: boolean;
   changeState: MouseEventHandler<HTMLElement>;
+  animation: boolean;
 }
 
 interface Circle {
   isOn: boolean;
+  animation: boolean;
 }
 
 const ToggleButton = (props: Props) => {
-  const { isOn, changeState } = props;
+  const { isOn, changeState, animation } = props;
 
   return (
-    <Button onClick={changeState} isOn={isOn}>
-      <Circle isOn={isOn} />
+    <Button onClick={changeState} isOn={isOn} animation={animation}>
+      <Circle isOn={isOn} animation={animation} />
     </Button>
   );
 };
@@ -28,7 +30,8 @@ const Button = styled.button<Circle>`
   border: none;
   width: 3.2rem;
   height: 1.8rem;
-  transition: all 0.3s ease-in-out;
+
+  transition: ${(prop) => (prop.animation ? 'all 0.3s ease-in-out' : 'none')};
 
   background-color: ${(prop) => (prop.isOn ? THEME.PRIMARY : THEME.BACKGROUND)};
   border-radius: 1rem;
@@ -39,7 +42,7 @@ const Circle = styled.div<Circle>`
   border-radius: 50%;
   width: 1.2rem;
   height: 1.2rem;
-  transition: all 0.3s ease-in-out;
+  transition: ${(prop) => (prop.animation ? 'all 0.3s ease-in-out' : 'none')};
 
   background-color: #f5f5f5;
   top: 0.3rem;

--- a/src/components/Button/Toggle/index.tsx
+++ b/src/components/Button/Toggle/index.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { MouseEventHandler } from 'react';
+
+interface Props {
+  isOn: boolean;
+  changeState: MouseEventHandler<HTMLElement>;
+}
+
+interface Circle {
+  isOn: boolean;
+}
+
+const ToggleButton = (props: Props) => {
+  const { isOn, changeState } = props;
+
+  return (
+    <Button onClick={changeState} isOn={isOn}>
+      <Circle isOn={isOn} />
+    </Button>
+  );
+};
+
+export default ToggleButton;
+
+const Button = styled.button<Circle>`
+  position: relative;
+  border: none;
+  width: 3.2rem;
+  height: 1.8rem;
+  transition: all 0.3s ease-in-out;
+
+  background-color: ${(prop) => (prop.isOn ? THEME.PRIMARY : THEME.BACKGROUND)};
+  border-radius: 1rem;
+`;
+
+const Circle = styled.div<Circle>`
+  position: absolute;
+  border-radius: 50%;
+  width: 1.2rem;
+  height: 1.2rem;
+  transition: all 0.3s ease-in-out;
+
+  background-color: #f5f5f5;
+  top: 0.3rem;
+  left: ${(prop) => (prop.isOn ? '1.7rem' : '0.4rem')};
+`;

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -43,7 +43,7 @@ const DepartmentList = () => {
     closeModal(ConfirmModal);
     const storedSubscribe = localStorage.getItem('subscribe');
     if (major && storedSubscribe) {
-      http.delete(`${SERVER_URL}/api/subscription`, {
+      http.delete(`${SERVER_URL}/api/subscription/major`, {
         data: { storedSubscribe, major },
       });
     }

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -44,8 +44,9 @@ const DepartmentList = () => {
     const storedSubscribe = localStorage.getItem('subscribe');
     if (major && storedSubscribe) {
       http.delete(`${SERVER_URL}/api/subscription/major`, {
-        data: { storedSubscribe, major },
+        data: { subscription: JSON.parse(storedSubscribe), major },
       });
+      localStorage.removeItem('subscribe');
     }
     const afterSpace = selected.substring(selected.indexOf(' ') + 1);
     localStorage.setItem('major', afterSpace);

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -3,6 +3,7 @@ import Button from '@components/Button';
 import Icon from '@components/Icon';
 import AlertModal from '@components/Modal/AlertModal';
 import ConfirmModal from '@components/Modal/ConfirmModal';
+import { SERVER_URL } from '@config/index';
 import { MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -18,7 +19,7 @@ const DepartmentList = () => {
   const [selected, setSelected] = useState<string>('');
   const [buttonDisable, setButtonDisable] = useState<boolean>(true);
   const { routerTo, goBack } = useRouter();
-  const { setMajor } = useMajor();
+  const { major, setMajor } = useMajor();
   const { college } = useParams();
   const { openModal, closeModal } = useModals();
 
@@ -40,6 +41,12 @@ const DepartmentList = () => {
 
   const handlerMajorSetModal = () => {
     closeModal(ConfirmModal);
+    const storedSubscribe = localStorage.getItem('subscribe');
+    if (major && storedSubscribe) {
+      http.delete(`${SERVER_URL}/api/subscription`, {
+        data: { storedSubscribe, major },
+      });
+    }
     const afterSpace = selected.substring(selected.indexOf(' ') + 1);
     localStorage.setItem('major', afterSpace);
     setMajor(afterSpace);

--- a/src/hooks/urlBase64ToUint8Array.ts
+++ b/src/hooks/urlBase64ToUint8Array.ts
@@ -1,0 +1,14 @@
+const urlBase64ToUint8Array = (base64String: string) => {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+};
+
+export default urlBase64ToUint8Array;

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -3,6 +3,7 @@ import { setupWorker } from 'msw';
 import { announceHandlers } from './handlers/announceHandlers';
 import { graduationHandler } from './handlers/graudationHandler';
 import { majorHandlers } from './handlers/majorHandlers';
+import { subscribeHandler } from './handlers/subscribeHandler';
 import { testHandlers } from './handlers/testHandlers';
 
 export const worker = setupWorker(
@@ -10,4 +11,5 @@ export const worker = setupWorker(
   ...testHandlers,
   ...announceHandlers,
   ...graduationHandler,
+  ...subscribeHandler,
 ); // 브라우저 환경 서버

--- a/src/mocks/handlers/subscribeHandler.ts
+++ b/src/mocks/handlers/subscribeHandler.ts
@@ -1,0 +1,8 @@
+import { SERVER_URL } from '@config/index';
+import { RequestHandler, rest } from 'msw';
+
+export const subscribeHandler: RequestHandler[] = [
+  rest.post(SERVER_URL + '/api/subscription', (req, res, ctx) => {
+    return res(ctx.status(200));
+  }),
+];

--- a/src/mocks/handlers/subscribeHandler.ts
+++ b/src/mocks/handlers/subscribeHandler.ts
@@ -5,4 +5,7 @@ export const subscribeHandler: RequestHandler[] = [
   rest.post(SERVER_URL + '/api/subscription', (req, res, ctx) => {
     return res(ctx.status(200));
   }),
+  rest.delete(SERVER_URL + '/api/subscription', (req, res, ctx) => {
+    return res(ctx.status(200));
+  }),
 ];

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -2,10 +2,12 @@ import { setupServer } from 'msw/node';
 
 import { announceHandlers } from './handlers/announceHandlers';
 import { majorHandlers } from './handlers/majorHandlers';
+import { subscribeHandler } from './handlers/subscribeHandler';
 import { testHandlers } from './handlers/testHandlers';
 
 export const server = setupServer(
   ...majorHandlers,
   ...testHandlers,
   ...announceHandlers,
+  ...subscribeHandler,
 );

--- a/src/pages/My/index.test.tsx
+++ b/src/pages/My/index.test.tsx
@@ -62,7 +62,7 @@ describe('마이 페이지 동작 테스트', () => {
       { wrapper: MemoryRouter },
     );
 
-    const majorEditButton = screen.getByTestId('edit');
+    const majorEditButton = screen.getByText('학과 선택하러가기');
     await userEvent.click(majorEditButton);
     expect(mockRouterTo).toHaveBeenCalledWith('/major-decision');
   });

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -39,7 +39,7 @@ const My = () => {
       openModal(ConfirmModal, {
         message: '알림을 그만 받을까요?',
         onConfirmButtonClick: async () => {
-          await http.delete(`${SERVER_URL}/api/subscription`, {
+          await http.delete(`${SERVER_URL}/api/subscription/major`, {
             data: { subscribe, major },
           });
           setSubscribe(null);
@@ -75,7 +75,7 @@ const My = () => {
         applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
       });
 
-      const res = await http.post(`${SERVER_URL}/api/subscription`, {
+      const res = await http.post(`${SERVER_URL}/api/subscription/major`, {
         data: {
           subscription,
           major,

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -16,6 +16,7 @@ import { MouseEventHandler, useEffect, useState } from 'react';
 
 const My = () => {
   const [subscribe, setSubscribe] = useState<PushSubscription | null>(null);
+  const [animation, setAnimation] = useState(false);
 
   const { major } = useMajor();
   const { routerTo } = useRouter();
@@ -31,6 +32,8 @@ const My = () => {
   };
 
   const subscribeTopic: MouseEventHandler<HTMLElement> = async () => {
+    if (animation) setAnimation(true); // 토글 버튼 클릭 애니메이션을 위해 사용
+
     if (subscribe) {
       openModal(ConfirmModal, {
         message: '알림을 그만 받을까요?',
@@ -107,6 +110,7 @@ const My = () => {
             <ToggleButton
               isOn={Boolean(subscribe)}
               changeState={subscribeTopic}
+              animation={animation}
             />
           </CardList>
         </MajorCard>

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -6,6 +6,7 @@ import AlertModal from '@components/Modal/AlertModal';
 import ConfirmModal from '@components/Modal/ConfirmModal';
 import SuggestionModal from '@components/Modal/SuggestionModal';
 import { SERVER_URL } from '@config/index';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import urlBase64ToUint8Array from '@hooks/urlBase64ToUint8Array';
 import useMajor from '@hooks/useMajor';
@@ -100,16 +101,30 @@ const My = () => {
       <Major>
         <MajorCard>
           <CardList>
-            <div>{major}</div>
-            <Icon
-              kind="edit"
-              onClick={routerToMajorDecision}
-              color={THEME.TEXT.GRAY}
-              data-testid="edit"
-            />
+            {major ? (
+              <>
+                <div>{major}</div>
+                <Icon
+                  kind="edit"
+                  onClick={routerToMajorDecision}
+                  color={THEME.TEXT.GRAY}
+                  data-testid="edit"
+                />{' '}
+              </>
+            ) : (
+              <div
+                onClick={() => routerToMajorDecision()}
+                css={css`
+                  opacity: 0.5;
+                  width: 100%;
+                `}
+              >
+                학과 선택하러가기
+              </div>
+            )}
           </CardList>
           <CardList>
-            <span>공지사항 알림받기</span>
+            <span>학과 공지사항 알림받기</span>
             <ToggleButton
               isOn={Boolean(subscribe)}
               changeState={subscribeTopic}

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -40,10 +40,11 @@ const My = () => {
         message: '알림을 그만 받을까요?',
         onConfirmButtonClick: async () => {
           await http.delete(`${SERVER_URL}/api/subscription/major`, {
-            data: { subscribe, major },
+            data: { subscription: subscribe, major },
           });
           setSubscribe(null);
           closeModal(ConfirmModal);
+          localStorage.removeItem('subscribe');
         },
         onCancelButtonClick: () => {
           closeModal(ConfirmModal);

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -1,15 +1,17 @@
 import http from '@apis/http';
 import Button from '@components/Button';
+import ToggleButton from '@components/Button/Toggle';
 import Icon from '@components/Icon';
 import SuggestionModal from '@components/Modal/SuggestionModal';
 import { SERVER_URL } from '@config/index';
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import urlBase64ToUint8Array from '@hooks/urlBase64ToUint8Array';
 import useMajor from '@hooks/useMajor';
 import useModals from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
+import { MouseEventHandler, useState } from 'react';
+
 const subscribe = async () => {
   if (!('serviceWorker' in navigator)) return;
 
@@ -25,6 +27,8 @@ const subscribe = async () => {
 };
 
 const My = () => {
+  const [isToggleOn, setIsToggleOn] = useState(false);
+
   const { major } = useMajor();
   const { routerTo } = useRouter();
   const routerToMajorDecision = () => routerTo('/major-decision');
@@ -38,29 +42,30 @@ const My = () => {
     });
   };
 
+  const onClickToggle: MouseEventHandler<HTMLElement> = () => {
+    subscribe();
+    setIsToggleOn(!isToggleOn);
+  };
+
   return (
     <>
-      <h1>마이페이지</h1>
+      <Title>마이페이지</Title>
       <Major>
-        <span>전공</span>
-        <div
-          css={css`
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-          `}
-        >
-          <span>{major}</span>
-          <Icon
-            kind="edit"
-            onClick={routerToMajorDecision}
-            color={THEME.TEXT.GRAY}
-            data-testid="edit"
-          />
-        </div>
-        <Button data-testid="modal" onClick={subscribe}>
-          구독!
-        </Button>
+        <MajorCard>
+          <CardList>
+            <div>{major}</div>
+            <Icon
+              kind="edit"
+              onClick={routerToMajorDecision}
+              color={THEME.TEXT.GRAY}
+              data-testid="edit"
+            />
+          </CardList>
+          <CardList>
+            <span>공지사항 알림받기</span>
+            <ToggleButton isOn={isToggleOn} changeState={onClickToggle} />
+          </CardList>
+        </MajorCard>
       </Major>
       <Suggestion>
         <Button data-testid="modal" onClick={handleSuggestionModal}>
@@ -74,6 +79,14 @@ const My = () => {
 
 export default My;
 
+const Title = styled.div`
+  font-size: 1.5rem;
+  font-weight: bold;
+  padding-top: 5%;
+  padding-left: 4%;
+  margin-bottom: 5%;
+`;
+
 const Major = styled.div`
   display: flex;
   flex-direction: column;
@@ -86,4 +99,22 @@ const Suggestion = styled.div`
   bottom: 100px;
   left: 50%;
   transform: translate(-50%, -50%);
+`;
+
+const MajorCard = styled.div`
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
+    rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
+  width: 95%;
+  margin: 0 auto;
+  border-radius: 0.5rem;
+  align-items: center;
+  font-size: 1rem;
+`;
+
+const CardList = styled.div`
+  padding: 5%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 `;

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -68,11 +68,11 @@ const My = () => {
 
     try {
       const registration = await navigator.serviceWorker.ready;
+      const VAPID_PUBLIC_KEY =
+        'BMTktqZlaL5Bqx7rR2h_fbqBsWROO4k2RnXxwbJXDsP99RSaihgNEkA3JT1iQVT2XRQMRHYMJUyDQS7_r8S5BMc';
       const subscription = await registration.pushManager.subscribe({
         userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(
-          import.meta.env.VITE_PUBLIC_VAPID_KEY,
-        ),
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
       });
 
       const res = await http.post(`${SERVER_URL}/api/subscription`, {

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -83,6 +83,11 @@ const My = () => {
     }
   };
 
+  useEffect(() => {
+    const storedSubscribe = localStorage.getItem('subscribe');
+    if (storedSubscribe) setSubscribe(JSON.parse(storedSubscribe));
+  }, []);
+
   return (
     <>
       <Title>마이페이지</Title>

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -75,7 +75,10 @@ const My = () => {
       });
 
       const res = await http.post(`${SERVER_URL}/api/subscription`, {
-        data: subscription,
+        data: {
+          subscription,
+          major,
+        },
       });
       if (res.status === 200) {
         localStorage.setItem('subscribe', JSON.stringify(subscription));

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -1,12 +1,28 @@
+import http from '@apis/http';
 import Button from '@components/Button';
 import Icon from '@components/Icon';
 import SuggestionModal from '@components/Modal/SuggestionModal';
+import { SERVER_URL } from '@config/index';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import urlBase64ToUint8Array from '@hooks/urlBase64ToUint8Array';
 import useMajor from '@hooks/useMajor';
 import useModals from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
+const subscribe = async () => {
+  if (!('serviceWorker' in navigator)) return;
+
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(
+      import.meta.env.VITE_PUBLIC_VAPID_KEY,
+    ),
+  });
+
+  await http.post(`${SERVER_URL}/api/subscription`, { data: subscription });
+};
 
 const My = () => {
   const { major } = useMajor();
@@ -42,6 +58,9 @@ const My = () => {
             data-testid="edit"
           />
         </div>
+        <Button data-testid="modal" onClick={subscribe}>
+          구독!
+        </Button>
       </Major>
       <Suggestion>
         <Button data-testid="modal" onClick={handleSuggestionModal}>

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -38,8 +38,8 @@ const My = () => {
       openModal(ConfirmModal, {
         message: '알림을 그만 받을까요?',
         onConfirmButtonClick: async () => {
-          await http.post(`${SERVER_URL}/api/subscription/`, {
-            data: subscribe,
+          await http.delete(`${SERVER_URL}/api/subscription`, {
+            data: { subscribe, major },
           });
           setSubscribe(null);
           closeModal(ConfirmModal);

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -33,7 +33,7 @@ const My = () => {
   };
 
   const subscribeTopic: MouseEventHandler<HTMLElement> = async () => {
-    if (animation) setAnimation(true); // 토글 버튼 클릭 애니메이션을 위해 사용
+    if (!animation) setAnimation(true); // 토글 버튼 클릭 애니메이션을 위해 사용
 
     if (subscribe) {
       openModal(ConfirmModal, {

--- a/src/styles/Global/index.tsx
+++ b/src/styles/Global/index.tsx
@@ -103,6 +103,9 @@ const resetCss = css`
   section {
     display: block;
   }
+  * {
+    user-select: none;
+  }
   body {
     line-height: 1;
     max-width: 480px;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,100 +10,100 @@ export default defineConfig({
   plugins: [
     react(),
     tsconfigPaths(),
-    VitePWA({
-      manifest: {
-        name: '부림이',
-        short_name: '부림이',
-        start_url: '/',
-        display: 'fullscreen',
-        orientation: 'portrait',
-        background_color: '#ffffff',
-        theme_color: '#ffffff',
-        icons: [
-          {
-            src: 'icons/icon-48x48.png',
-            sizes: '48x48',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-          {
-            src: 'icons/icon-72x72.png',
-            sizes: '72x72',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-          {
-            src: 'icons/icon-96x96.png',
-            sizes: '96x96',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-          {
-            src: 'icons/icon-128x128.png',
-            sizes: '128x128',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-          {
-            src: 'icons/icon-144x144.png',
-            sizes: '144x144',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-          {
-            src: 'icons/icon-152x152.png',
-            sizes: '152x152',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-          {
-            src: 'icons/icon-192x192.png',
-            sizes: '192x192',
-            type: 'image/png',
-            purpose: 'any maskable',
-          },
-          {
-            src: 'icons/icon-384x384.png',
-            sizes: '384x384',
-            type: 'image/png',
-          },
-          {
-            src: 'icons/icon-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-          },
-        ],
-      },
-      workbox: {
-        globPatterns: ['**/*'],
-        navigationPreload: true,
-        navigateFallback: 'index.html',
-        runtimeCaching: [
-          {
-            urlPattern: new RegExp('^/api/majorDecision'),
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'api-major-decision-cache',
-              expiration: {
-                maxEntries: 10,
-                maxAgeSeconds: 60 * 60 * 24 * 15, // 15일
-              },
-            },
-          },
-          {
-            urlPattern: new RegExp('^/api/announcement'),
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: 'announcement-cache',
-              expiration: {
-                maxAgeSeconds: 60 * 60 * 24, // 24시간
-              },
-            },
-          },
-        ],
-      },
-      includeAssets: ['**/*'],
-    }),
+    // VitePWA({
+    //   manifest: {
+    //     name: '부림이',
+    //     short_name: '부림이',
+    //     start_url: '/',
+    //     display: 'fullscreen',
+    //     orientation: 'portrait',
+    //     background_color: '#ffffff',
+    //     theme_color: '#ffffff',
+    //     icons: [
+    //       {
+    //         src: 'icons/icon-48x48.png',
+    //         sizes: '48x48',
+    //         type: 'image/png',
+    //         purpose: 'any maskable',
+    //       },
+    //       {
+    //         src: 'icons/icon-72x72.png',
+    //         sizes: '72x72',
+    //         type: 'image/png',
+    //         purpose: 'any maskable',
+    //       },
+    //       {
+    //         src: 'icons/icon-96x96.png',
+    //         sizes: '96x96',
+    //         type: 'image/png',
+    //         purpose: 'any maskable',
+    //       },
+    //       {
+    //         src: 'icons/icon-128x128.png',
+    //         sizes: '128x128',
+    //         type: 'image/png',
+    //         purpose: 'any maskable',
+    //       },
+    //       {
+    //         src: 'icons/icon-144x144.png',
+    //         sizes: '144x144',
+    //         type: 'image/png',
+    //         purpose: 'any maskable',
+    //       },
+    //       {
+    //         src: 'icons/icon-152x152.png',
+    //         sizes: '152x152',
+    //         type: 'image/png',
+    //         purpose: 'any maskable',
+    //       },
+    //       {
+    //         src: 'icons/icon-192x192.png',
+    //         sizes: '192x192',
+    //         type: 'image/png',
+    //         purpose: 'any maskable',
+    //       },
+    //       {
+    //         src: 'icons/icon-384x384.png',
+    //         sizes: '384x384',
+    //         type: 'image/png',
+    //       },
+    //       {
+    //         src: 'icons/icon-512x512.png',
+    //         sizes: '512x512',
+    //         type: 'image/png',
+    //       },
+    //     ],
+    //   },
+    //   workbox: {
+    //     globPatterns: ['**/*'],
+    //     navigationPreload: true,
+    //     navigateFallback: 'index.html',
+    //     runtimeCaching: [
+    //       {
+    //         urlPattern: new RegExp('^/api/majorDecision'),
+    //         handler: 'CacheFirst',
+    //         options: {
+    //           cacheName: 'api-major-decision-cache',
+    //           expiration: {
+    //             maxEntries: 10,
+    //             maxAgeSeconds: 60 * 60 * 24 * 15, // 15일
+    //           },
+    //         },
+    //       },
+    //       {
+    //         urlPattern: new RegExp('^/api/announcement'),
+    //         handler: 'StaleWhileRevalidate',
+    //         options: {
+    //           cacheName: 'announcement-cache',
+    //           expiration: {
+    //             maxAgeSeconds: 60 * 60 * 24, // 24시간
+    //           },
+    //         },
+    //       },
+    //     ],
+    //   },
+    //   includeAssets: ['**/*'],
+    // }),
   ],
   resolve: {
     alias: [


### PR DESCRIPTION
## 🤠 개요

- closes: #161 
- 알림 허용 시 서비스워커에서 알림을 받을 수 있도록 기능을 추가했어요
- 마이페이지 디자인을 개선했어요!
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 학교 공지사항 알림 & 학과 공지사항 알림
- 일단 학과 공지사항 알림만 할 수 있도록 추가했어요
- 만약 학과 공지사항 알림이 잘 된다면 학교 공지사항 알림도 쉽게 추가할 수 있을거 같아요!

## 알림은 몇개..?
- 만약 새로운 공지사항이 올라왔으면 올라온 모든 공지사항을 알림으로 보낼건지, 아니면 새로운 공지가 있다고 알림 1개만 보낼 지 고민해봐야할거 같아요 

## 알림 허용 문제
- PWA 는 웹 브라우저에서 돌아가기 때문에 만약 사용자가 웹 브라우저의 알림을 껐다면 알림을 받을 수 없어요..
- 마이페이지 하단에 알림을 받을 수 있는 가이드라인을 하나 만들어야할 것 같아요

## 알림 방법
- 알림을 받는 방법은 추후 부리미 기술 블로그에 상세히 작성해둘게요!
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
![Screen Recording 2023-08-20 at 11 41 02 AM](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/95fb51b3-4b17-44eb-9f3f-bdf75daf478e)
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/700853e2-6d98-40d6-86eb-31048f9bd370)
