### PR TITLE
Fix/#189: 모달창 크기 수정

### DIFF
--- a/src/components/Modal/SuggestionModal/index.tsx
+++ b/src/components/Modal/SuggestionModal/index.tsx
@@ -110,7 +110,7 @@ const SuggestionArea = styled.textarea`
   line-height: 1.5;
   padding: 10px;
   resize: none;
-  overflow-y: hidden;
+  overflow-y: scoll;
 
   font-size: 16px;
   font-weight: bold;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -53,6 +53,9 @@ const ModalContent = styled.div`
 
   animation: ${modalIn} 0.3s ease-out;
   width: 80%;
+  max-width: 480px;
+  max-height: 70vh;
+  overflow: auto;
   padding: 30px;
   border-radius: 15px;
   background-color: ${THEME.TEXT.WHITE};


### PR DESCRIPTION
## 🤠 개요

- closes: #189 
- 모달창의 가로크기도 최대 480px 로 설정했어요
- 세로 크기를 뷰포트의 60%로 설정해서 overflow되면 scroll 되게 수정했어요
- 회신받을 이메일 입력하는 공간은 지금 필요하지 않을거 같아서 추가하지 않았어요.. 나중에 필요하면 추가할게요 (추가할려고 했는데 UI가 안예뻐요..)
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
