### PR TITLE
Style/#166: 공지사항 페이지 디자인 개선

### DIFF
--- a/src/components/Card/AnnounceCard/Skeleton.tsx
+++ b/src/components/Card/AnnounceCard/Skeleton.tsx
@@ -10,19 +10,19 @@ const AnnounceCardSkeleton = ({ length }: AnnounceCardSkeletonProps) => {
   return (
     <>
       {Array.from({ length }, (_, idx) => (
-        <div key={idx}>
-          <Wrapper>
-            <Title></Title>
+        <Card key={idx}>
+          <ContentContainer>
+            <AnnounceTitle></AnnounceTitle>
             <div
               css={css`
                 border-left: 1px solid gray;
                 height: 12px;
-                margin: 0 10px;
+                margin: 0 5px;
               `}
             />
-            <Date></Date>
-          </Wrapper>
-        </div>
+            <AnnounceDate></AnnounceDate>
+          </ContentContainer>
+        </Card>
       ))}
     </>
   );
@@ -30,20 +30,25 @@ const AnnounceCardSkeleton = ({ length }: AnnounceCardSkeletonProps) => {
 
 export default AnnounceCardSkeleton;
 
-const Wrapper = styled.div`
-  display: flex;
+const Card = styled.div`
+  height: 28px;
   padding: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const ContentContainer = styled.div`
+  display: flex;
   align-items: center;
 `;
 
-const Title = styled(SkeletomItem)`
+const AnnounceTitle = styled(SkeletomItem)`
   flex: 9;
-  width: 100%;
-  height: 30px;
 `;
 
-const Date = styled(SkeletomItem)`
+const AnnounceDate = styled(SkeletomItem)`
   flex: 1;
-  width: 100%;
-  height: 20px;
+  height: 10px;
+  justify-content: flex-end;
 `;

--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -17,25 +17,23 @@ const AnnounceCard = ({
   const onClick = () => {
     window.open(link, '_blank');
   };
+
+  uploadDate = uploadDate.slice(2);
+
   return (
     <Card onClick={onClick} data-testid="card">
-      <div
-        css={css`
-          display: flex;
-          align-items: center;
-        `}
-      >
+      <ContentContainer>
         {pinned && <Icon kind="speaker" color={THEME.PRIMARY} />}
-        <span>{title}</span>
-        <div
+        <AnnounceTitle pinned={pinned}>{title}</AnnounceTitle>
+        <VertialSeparator
           css={css`
             border-left: 1px solid gray;
             height: 12px;
-            margin: 0 10px;
+            margin: 0 5px;
           `}
         />
-        <span>{uploadDate}</span>
-      </div>
+        <AnnounceDate>{uploadDate}</AnnounceDate>
+      </ContentContainer>
     </Card>
   );
 };
@@ -43,24 +41,43 @@ const AnnounceCard = ({
 export default AnnounceCard;
 
 const Card = styled.div`
+  height: 28px;
+  padding: 10px;
   display: flex;
   flex-direction: column;
-
-  padding: 10px;
-  cursor: pointer;
+  justify-content: center;
 
   color: ${THEME.TEXT.BLACK};
+`;
 
-  & > div > span:first-of-type {
-    font-size: 18px;
-    font-weight: bold;
-    flex: 9;
-    text-align: center;
-  }
+const ContentContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
 
-  & > div > span:nth-of-type(2) {
-    font-size: 12px;
-    flex: 1;
-    text-align: center;
-  }
+const AnnounceTitle = styled.span<{ pinned: boolean }>`
+  flex: 9;
+  font-size: 15px;
+  font-weight: ${({ pinned }) => (pinned ? 'bold' : 500)};
+  margin-left: ${({ pinned }) => (pinned ? '' : '28px')};
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const VertialSeparator = styled.div`
+  border-left: 1px solid gray;
+  height: 12px;
+  margin: 0 5px;
+`;
+
+const AnnounceDate = styled.span`
+  flex: 1;
+  font-size: 10px;
+  font-weight: bold;
+  text-align: end;
+  white-space: nowrap;
+
+  color: ${THEME.TEXT.GRAY};
 `;

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -4,19 +4,35 @@ import AnnounceList from '@components/Card/AnnounceCard/AnnounceList';
 import AnnounceCardSkeleton from '@components/Card/AnnounceCard/Skeleton';
 import AlertModal from '@components/Modal/AlertModal';
 import { MODAL_MESSAGE } from '@constants/modal-messages';
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
 import useModals from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
+
+type AnimationType = 'bottomBar' | 'announce';
+type GetAnimationType = (type: AnimationType) => string;
 
 const Announcement = () => {
   const { major } = useMajor();
   const { routerTo } = useRouter();
   const { openModal, closeModal } = useModals();
+  const [activeAnimation, setActiveAnimation] = useState<boolean>(false);
+
   const routerToMajorDecision = () => routerTo('/major-decision');
+
   const announceKeyword = decodeURI(window.location.pathname.split('/')[2]);
+  const isKeywordUndefined = () => announceKeyword === 'undefined';
+
+  const getAnimationType: GetAnimationType = (type) => {
+    if (!activeAnimation) return 'none';
+    if (type === 'bottomBar') {
+      return !isKeywordUndefined() ? BottomBarSlideRight : BottomBarSlideLeft;
+    }
+    return !isKeywordUndefined() ? AnnounceSlideRight : AnnounceSlideLeft;
+  };
 
   const handleMajorAnnouncements = () => {
     if (!major) {
@@ -32,23 +48,25 @@ const Announcement = () => {
       });
       return;
     }
+    if (!activeAnimation) {
+      setActiveAnimation((prev) => !prev);
+    }
     routerTo(`${major}`);
   };
-
-  const isKeywordUndefined = () => announceKeyword === 'undefined';
 
   return (
     <>
       <div
         css={css`
+          width: inherit;
           display: flex;
+          position: relative;
+          overflow-x: hidden;
         `}
       >
         <Button
           onClick={() => routerTo('')}
           css={css`
-            border-bottom: ${isKeywordUndefined() &&
-            `3px solid ${THEME.PRIMARY}`};
             border-radius: 0px;
             background-color: ${THEME.TEXT.WHITE};
             color: ${isKeywordUndefined() ? THEME.PRIMARY : THEME.TEXT.BLACK};
@@ -59,8 +77,6 @@ const Announcement = () => {
         <Button
           onClick={() => handleMajorAnnouncements()}
           css={css`
-            border-bottom: ${!isKeywordUndefined() &&
-            `3px solid ${THEME.PRIMARY}`};
             border-radius: 0px;
             background-color: ${THEME.TEXT.WHITE};
             color: ${isKeywordUndefined() ? THEME.TEXT.BLACK : THEME.PRIMARY};
@@ -68,15 +84,74 @@ const Announcement = () => {
         >
           학과 공지사항
         </Button>
+        <BottomBar getAnimationType={getAnimationType} />
       </div>
-      <Suspense fallback={<AnnounceCardSkeleton length={30} />}>
-        <AnnounceList
-          resource={fetchAnnounceList(
-            announceKeyword !== 'undefined' ? announceKeyword : '',
-          )}
-        />
-      </Suspense>
+      <AnnounceContainer getAnimationType={getAnimationType}>
+        <Suspense fallback={<AnnounceCardSkeleton length={30} />}>
+          <AnnounceList
+            resource={fetchAnnounceList(
+              announceKeyword !== 'undefined' ? announceKeyword : '',
+            )}
+          />
+        </Suspense>
+      </AnnounceContainer>
     </>
   );
 };
+
 export default Announcement;
+
+const BottomBar = styled.span<{ getAnimationType: GetAnimationType }>`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+  height: 3px;
+  background-color: ${THEME.PRIMARY};
+  animation: ${({ getAnimationType }) => getAnimationType('bottomBar')} 0.3s
+    forwards;
+`;
+
+const AnnounceContainer = styled.div<{ getAnimationType: GetAnimationType }>`
+  width: 100%;
+  animation: ${({ getAnimationType }) => getAnimationType('announce')} 0.3s
+    forwards;
+`;
+
+const BottomBarSlideRight = keyframes`
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+`;
+
+const BottomBarSlideLeft = keyframes`
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0%);
+  }
+`;
+
+const AnnounceSlideRight = keyframes`
+  from {
+    transform: translateX(-100%);
+    display: none;
+  }
+  to {
+    transform: translateX(0%);
+  }
+`;
+
+const AnnounceSlideLeft = keyframes`
+  from {
+    transform: translateX(200%);
+    display: none;
+  }
+  to {
+    transform: translateX(0%);
+  }
+`;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
- closes : #166 
- 공지사항 페이지 디자인을 수정했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->
- 공지사항 제목이 1줄만 나오도록 설정하고, 모바일 기준 font-sizer가 너무 큰 것 같아서 조금 줄였어요
- 슬라이드 애니메이션을 적용하긴 했는데 데스크탑 환경에서는 화면 영역을 벗어난곳에서 애니메이션이 시작되어서 이상하지만, 모바일 환경에서는 괜찮은 것 같아요
- 고정이 아닌 일반 공지사항도 고정아이콘 speaker만큼 margin-left를 두긴 했는데 이상하면 화면 제일 왼쪽에 붙여버려도 괜찮을 것 같아요

## 📷 스크린샷 (Optional)

https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/68489467/231fa3be-1d11-42bd-a46d-b59cb1c5ad35
