### PR TITLE
Style/#192: 단과대, 학과 선택 페이지 로딩화면에 서스펜스 적용

### DIFF
--- a/src/apis/Suspense/fetch-major-list.ts
+++ b/src/apis/Suspense/fetch-major-list.ts
@@ -1,0 +1,14 @@
+import { AxiosResponse } from 'axios';
+
+import wrapPromise from './wrap-promise';
+import http from '../http';
+
+const fetchMajorList = <T>(department?: string) => {
+  const promise: Promise<AxiosResponse<T>> = http
+    .get(department ? `/api/majorDecision/${department}` : `/api/majorDecision`)
+    .then((res) => res.data);
+
+  return wrapPromise<T>(promise);
+};
+
+export default fetchMajorList;

--- a/src/components/List/CollegeList/CollegeItem.tsx
+++ b/src/components/List/CollegeList/CollegeItem.tsx
@@ -1,0 +1,51 @@
+import Icon from '@components/Icon';
+import styled from '@emotion/styled';
+import useRouter from '@hooks/useRouter';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { AxiosError, AxiosResponse } from 'axios';
+import React from 'react';
+
+type College = string[];
+type Resource = AxiosResponse<College> | College | AxiosError | null;
+interface CollegeItemProps {
+  resource: {
+    read: () => Resource;
+  };
+}
+
+const CollegeItem = ({ resource }: CollegeItemProps) => {
+  const majorList = resource.read();
+  if (majorList === null || majorList instanceof Error) return null;
+
+  const { routerTo } = useRouter();
+
+  const handleDepartmentClick: React.MouseEventHandler<HTMLElement> = (e) => {
+    const collegeName = e.currentTarget.textContent;
+    if (collegeName === null) routerTo('/major-decision');
+    else routerTo(`/major-decision/${collegeName}`);
+  };
+
+  return (
+    <>
+      {(majorList as College).map((college, index) => (
+        <ListWrapper key={index} onClick={handleDepartmentClick}>
+          {college}
+          <Icon kind="right" size="28" />
+        </ListWrapper>
+      ))}
+    </>
+  );
+};
+
+export default CollegeItem;
+
+const ListWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 90%;
+  margin: 0 auto;
+  padding: 8% 6% 8% 6%;
+  border-bottom: 1px solid ${THEME.BUTTON.GRAY};
+`;

--- a/src/components/List/CollegeList/index.tsx
+++ b/src/components/List/CollegeList/index.tsx
@@ -1,76 +1,29 @@
-import http from '@apis/http';
-import Icon from '@components/Icon';
-import { css } from '@emotion/react';
+import fetchMajorList from '@apis/Suspense/fetch-major-list';
 import styled from '@emotion/styled';
-import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
-import React, { useState, useEffect } from 'react';
+import React, { Suspense } from 'react';
+
+import CollegeItem from './CollegeItem';
+import CollegeSkeleton from '../Skeleton/college';
 
 const CollegeList = () => {
-  const [collegeList, setCollegeList] = useState<string[]>();
-  const { routerTo } = useRouter();
-
-  useEffect(() => {
-    fetchData();
-  }, []);
-
-  const fetchData = async () => {
-    const result = await http.get('/api/majorDecision');
-    setCollegeList(result.data);
-  };
-
-  const onClick: React.MouseEventHandler<HTMLElement> = (e) => {
-    const collegeName = e.currentTarget.textContent;
-
-    if (collegeName === null) routerTo('/major-decision');
-    else routerTo(`/major-decision/${collegeName}`);
-  };
-
-  return collegeList ? (
-    <ListContainer>
+  return (
+    <>
       <Title>단과대 선택하기</Title>
-      {collegeList.map((college) => (
-        <div
-          key={college}
-          css={css`
-            width: 100%;
-          `}
-          onClick={onClick}
-        >
-          <ListWrapper>
-            {college}
-            <IconWrapper>
-              <Icon kind="right" />
-            </IconWrapper>
-          </ListWrapper>
-        </div>
-      ))}
-    </ListContainer>
-  ) : (
-    <div>loading...</div>
+      <Suspense fallback={<CollegeSkeleton length={10} />}>
+        <CollegeItem resource={fetchMajorList<string[]>()} />
+      </Suspense>
+    </>
   );
 };
 
-const ListContainer = styled.div`
-  padding-top: 2%;
-  padding-left: 2%;
-`;
-
-const ListWrapper = styled.div`
-  padding: 8% 6% 8% 6%;
-  width: 80%;
-  margin: 0 auto;
-  border-bottom: 1px solid ${THEME.BUTTON.GRAY};
-`;
-
-const IconWrapper = styled.div`
-  float: right;
-`;
-
 const Title = styled.h2`
-  font-size: 1.5rem;
-  margin-bottom: 3%;
-  padding-left: 5%;
+  font-size: 24px;
+  text-align: center;
+  margin: 0 auto;
+  margin-top: 10px;
+  color: ${THEME.TEXT.GRAY};
+  font-weight: bold;
 `;
 
 export default CollegeList;

--- a/src/components/List/DepartmentList/DepartmentItem.tsx
+++ b/src/components/List/DepartmentList/DepartmentItem.tsx
@@ -1,0 +1,131 @@
+import http from '@apis/http';
+import Button from '@components/Button';
+import Icon from '@components/Icon';
+import AlertModal from '@components/Modal/AlertModal';
+import ConfirmModal from '@components/Modal/ConfirmModal';
+import { SERVER_URL } from '@config/index';
+import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import useMajor from '@hooks/useMajor';
+import useModals from '@hooks/useModals';
+import useRouter from '@hooks/useRouter';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { AxiosError, AxiosResponse } from 'axios';
+import React, { useState } from 'react';
+
+type Department = string[];
+type Resource = AxiosResponse<Department> | Department | AxiosError | null;
+interface DepartmentItemProps {
+  resource: {
+    read: () => Resource;
+  };
+}
+
+const DepartmentItem = ({ resource }: DepartmentItemProps) => {
+  const majorList = resource.read();
+  if (majorList === null || majorList instanceof Error) return null;
+
+  const { routerTo } = useRouter();
+  const { major, setMajor } = useMajor();
+  const { openModal, closeModal } = useModals();
+  const [selected, setSelected] = useState<string>('');
+  const [buttonDisable, setButtonDisable] = useState<boolean>(true);
+
+  const routerToHome = () => {
+    closeModal(AlertModal);
+    routerTo('/');
+  };
+  const handleMajorClick: React.MouseEventHandler<HTMLElement> = (e) => {
+    if (e.currentTarget.textContent === null) return;
+    setSelected(e.currentTarget.textContent);
+    setButtonDisable(false);
+  };
+
+  const handlerMajorSetModal = () => {
+    closeModal(ConfirmModal);
+
+    const storedSubscribe = localStorage.getItem('subscribe');
+    if (major && storedSubscribe) {
+      http.delete(`${SERVER_URL}/api/subscription/major`, {
+        data: { subscription: JSON.parse(storedSubscribe), major },
+      });
+      localStorage.removeItem('subscribe');
+    }
+    const afterSpace = selected.substring(selected.indexOf(' ') + 1);
+    localStorage.setItem('major', afterSpace);
+    setMajor(afterSpace);
+
+    openModal(AlertModal, {
+      message: MODAL_MESSAGE.SUCCEED.SET_MAJOR,
+      buttonMessage: '홈으로 이동하기',
+      onClose: () => routerToHome(),
+      routerTo: () => routerToHome(),
+    });
+  };
+  const handleMajorConfirmModal = () => {
+    openModal(ConfirmModal, {
+      message: MODAL_MESSAGE.CONFIRM.SET_MAJOR,
+      onConfirmButtonClick: () => handlerMajorSetModal(),
+      onCancelButtonClick: () => closeModal(ConfirmModal),
+    });
+  };
+
+  return (
+    <>
+      <div
+        css={css`
+          height: 60vh;
+        `}
+      >
+        {(majorList as Department).map((department, index) => (
+          <ListWrapper key={index} onClick={handleMajorClick}>
+            {department}
+            <Icon
+              kind={selected === department ? 'checkedRadio' : 'uncheckedRadio'}
+              color={selected === department ? THEME.PRIMARY : THEME.TEXT.GRAY}
+              size="28"
+            />
+          </ListWrapper>
+        ))}
+      </div>
+      <ButtonContainer>
+        <Button disabled={buttonDisable} onClick={handleMajorConfirmModal}>
+          선택완료
+        </Button>
+      </ButtonContainer>
+    </>
+  );
+};
+
+export default DepartmentItem;
+
+const ListWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 6% 4% 6% 4%;
+  width: 90%;
+  margin: 0 auto;
+  border-bottom: 1px solid ${THEME.BUTTON.GRAY};
+`;
+
+const ButtonContainer = styled.div`
+  position: fixed;
+  bottom: 4%;
+  z-index: 3;
+  width: 80%;
+  max-width: 480px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  Button {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    & > svg {
+      margin-right: 15px;
+    }
+  }
+`;

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -1,161 +1,36 @@
-import http from '@apis/http';
-import Button from '@components/Button';
-import Icon from '@components/Icon';
-import AlertModal from '@components/Modal/AlertModal';
-import ConfirmModal from '@components/Modal/ConfirmModal';
-import { SERVER_URL } from '@config/index';
-import { MODAL_MESSAGE } from '@constants/modal-messages';
-import { css } from '@emotion/react';
+import fetchMajorList from '@apis/Suspense/fetch-major-list';
+import DEPARTMENT_LENGTH from '@constants/department-length';
 import styled from '@emotion/styled';
-import useMajor from '@hooks/useMajor';
-import useModals from '@hooks/useModals';
-import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
-import React, { useEffect, useState } from 'react';
+import React, { Suspense } from 'react';
 import { useParams } from 'react-router-dom';
 
+import DepartmentItem from './DepartmentItem';
+import DepartmentSkeleton from '../Skeleton/department';
+
 const DepartmentList = () => {
-  const [departmentList, setDepartmentList] = useState<string[]>();
-  const [selected, setSelected] = useState<string>('');
-  const [buttonDisable, setButtonDisable] = useState<boolean>(true);
-  const { routerTo, goBack } = useRouter();
-  const { major, setMajor } = useMajor();
   const { college } = useParams();
-  const { openModal, closeModal } = useModals();
-
-  const fetchData = async () => {
-    const result = await http.get(`/api/majorDecision/${college}`);
-    if (result.data === undefined) {
-      goBack();
-    }
-    setDepartmentList(result.data);
-  };
-  useEffect(() => {
-    fetchData();
-  }, []);
-
-  const routerToHome = () => {
-    closeModal(AlertModal);
-    routerTo('/');
-  };
-
-  const handlerMajorSetModal = () => {
-    closeModal(ConfirmModal);
-    const storedSubscribe = localStorage.getItem('subscribe');
-    if (major && storedSubscribe) {
-      http.delete(`${SERVER_URL}/api/subscription/major`, {
-        data: { subscription: JSON.parse(storedSubscribe), major },
-      });
-      localStorage.removeItem('subscribe');
-    }
-    const afterSpace = selected.substring(selected.indexOf(' ') + 1);
-    localStorage.setItem('major', afterSpace);
-    setMajor(afterSpace);
-
-    openModal(AlertModal, {
-      message: MODAL_MESSAGE.SUCCEED.SET_MAJOR,
-      buttonMessage: '홈으로 이동하기',
-      onClose: () => routerToHome(),
-      routerTo: () => routerToHome(),
-    });
-  };
-
-  const handleMajorConfirmModal = () => {
-    openModal(ConfirmModal, {
-      message: MODAL_MESSAGE.CONFIRM.SET_MAJOR,
-      onConfirmButtonClick: () => handlerMajorSetModal(),
-      onCancelButtonClick: () => closeModal(ConfirmModal),
-    });
-  };
-
-  const onClick: React.MouseEventHandler<HTMLElement> = (e) => {
-    if (e.currentTarget.textContent === null) return;
-    setSelected(e.currentTarget.textContent);
-    setButtonDisable(false);
-  };
-
-  return departmentList ? (
-    <ListContainer>
+  return (
+    <>
       <Title>학과 선택하기</Title>
-      <div
-        css={css`
-          height: 60vh;
-        `}
+      <Suspense
+        fallback={
+          <DepartmentSkeleton length={DEPARTMENT_LENGTH[college as string]} />
+        }
       >
-        {departmentList.map((department) => (
-          <div
-            key={department}
-            css={css`
-              width: 100%;
-            `}
-            onClick={onClick}
-          >
-            <ListWrapper>
-              {department}
-              <Icon
-                kind={
-                  selected === department ? 'checkedRadio' : 'uncheckedRadio'
-                }
-                color={
-                  selected === department ? THEME.PRIMARY : THEME.TEXT.GRAY
-                }
-                size="24"
-              />
-            </ListWrapper>
-          </div>
-        ))}
-      </div>
-      <ButtonContainer>
-        <Button disabled={buttonDisable} onClick={handleMajorConfirmModal}>
-          선택완료
-        </Button>
-      </ButtonContainer>
-    </ListContainer>
-  ) : (
-    <div>loading..</div>
+        <DepartmentItem resource={fetchMajorList<string[]>(college)} />
+      </Suspense>
+    </>
   );
 };
 
-const ButtonContainer = styled.div`
-  position: fixed;
-  bottom: 4%;
-  z-index: 3;
-  width: 80%;
-  max-width: 480px;
-  left: 50%;
-  transform: translate(-50%, -50%);
-
-  Button {
-    display: flex;
-    align-items: center;
-    padding: 10px;
-    & > svg {
-      margin-right: 15px;
-    }
-  }
-`;
-
-const ListContainer = styled.div`
-  padding-top: 2%;
-  padding-left: 2%;
-  padding-bottom: 15%;
-  overflow: auto;
-`;
-
 const Title = styled.h2`
-  font-size: 1.5rem;
-  margin-bottom: 3%;
-  padding-left: 5%;
-`;
-
-const ListWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 80%;
+  font-size: 24px;
+  text-align: center;
   margin: 0 auto;
-  border-bottom: 1px solid ${THEME.BUTTON.GRAY};
-  padding: 8% 6% 8% 6%;
+  margin-top: 10px;
+  color: ${THEME.TEXT.GRAY};
+  font-weight: bold;
 `;
 
 export default DepartmentList;

--- a/src/components/List/Skeleton/college.tsx
+++ b/src/components/List/Skeleton/college.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+import SkeletomItem from '@styles/Skeleton/SkeletonItem';
+import { THEME } from '@styles/ThemeProvider/theme';
+import React from 'react';
+
+interface CollegeSkeletonProps {
+  length: number;
+}
+
+const CollegeSkeleton = ({ length }: CollegeSkeletonProps) => {
+  return (
+    <>
+      {Array.from({ length }, (_, idx) => (
+        <ListWrapper key={idx}>
+          <College></College>
+          <Icon></Icon>
+        </ListWrapper>
+      ))}
+    </>
+  );
+};
+
+export default CollegeSkeleton;
+
+const ListWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 8% 6% 8% 6%;
+  width: 90%;
+  margin: 0 auto;
+  border-bottom: 1px solid ${THEME.BUTTON.GRAY};
+`;
+
+const College = styled(SkeletomItem)`
+  height: 28px;
+  width: 60%;
+`;
+
+const Icon = styled(SkeletomItem)`
+  height: 28px;
+  width: 28px;
+`;

--- a/src/components/List/Skeleton/department.tsx
+++ b/src/components/List/Skeleton/department.tsx
@@ -1,0 +1,74 @@
+import Button from '@components/Button';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import SkeletomItem from '@styles/Skeleton/SkeletonItem';
+import { THEME } from '@styles/ThemeProvider/theme';
+import React from 'react';
+
+interface DepartmentSkeletonProps {
+  length: number;
+}
+
+const DepartmentSkeleton = ({ length }: DepartmentSkeletonProps) => {
+  return (
+    <>
+      <div
+        css={css`
+          height: 60vh;
+        `}
+      >
+        {Array.from({ length }, (_, idx) => (
+          <ListWrapper key={idx}>
+            <Department></Department>
+            <Icon></Icon>
+          </ListWrapper>
+        ))}
+      </div>
+      <ButtonContainer>
+        <Button disabled={true}>선택완료</Button>
+      </ButtonContainer>
+    </>
+  );
+};
+
+export default DepartmentSkeleton;
+
+const ListWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 8% 6% 8% 6%;
+  width: 90%;
+  margin: 0 auto;
+  border-bottom: 1px solid ${THEME.BUTTON.GRAY};
+`;
+
+const Department = styled(SkeletomItem)`
+  height: 28px;
+  width: 60%;
+`;
+
+const Icon = styled(SkeletomItem)`
+  height: 28px;
+  width: 28px;
+`;
+
+const ButtonContainer = styled.div`
+  position: fixed;
+  bottom: 4%;
+  z-index: 3;
+  width: 80%;
+  max-width: 480px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  Button {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    & > svg {
+      margin-right: 15px;
+    }
+  }
+`;

--- a/src/constants/department-length.ts
+++ b/src/constants/department-length.ts
@@ -1,0 +1,17 @@
+interface MajorLength {
+  [key: string]: number;
+}
+
+const DEPARTMENT_LENGTH: MajorLength = {
+  DEFAULT: 8,
+  경영대학: 2,
+  공과대학: 22,
+  글로벌자율전공학부: 1,
+  수산과학대학: 10,
+  인문사회과학대학: 12,
+  자연과학대학: 6,
+  정보융합대학: 12,
+  환경·해양대학: 7,
+};
+
+export default DEPARTMENT_LENGTH;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
- closes: #192 
- 단과대, 학과 선택 페이지 로딩화면에 서스펜스를 적용해서 스켈레톤 UI를 사용했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->
- 이번에 구현하면서, 단과대와 학과 컴포넌트를 합쳐보려고 했지만 아이콘의 로직이 너무 달라서 분리된 상태로 계속 사용하기로 했어요
  - 추상화를 잘하면 List 컴포넌트로 분리할 수 있을 것 같지만, 다른 많은 페이지들 에서 사용하는 것이 아니라 학과 선택 페이지에서만 호출해서 사용할 컴포넌트를 추상화 하는것은 효율적이지 않다고 판단하기도 했어요

## 📷 스크린샷 (Optional)

https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/68489467/b446c0c4-bcb7-47ac-8000-39d3067444f0
