### PR TITLE
Feat/#84: 홈 화면에 캐러셀 추가

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ export default {
     '^@hooks/(.*)$': '<rootDir>/src/hooks/$1',
     '^@pages/(.*)$': '<rootDir>/src/pages/$1',
     '^@assets/(.*)$': '<rootDir>/public/assets/$1',
+    '\\.(css|less)$': 'identity-obj-proxy',
   },
   setupFilesAfterEnv: ['./src/jest.setup.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@emotion/styled": "^11.10.6",
     "@react-icons/all-files": "^4.1.0",
     "axios": "^1.3.5",
+    "identity-obj-proxy": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-ga4": "^2.1.0",

--- a/src/components/Card/InformCard/index.tsx
+++ b/src/components/Card/InformCard/index.tsx
@@ -112,12 +112,12 @@ const Card = styled.div`
 `;
 
 const Wrapper = styled.div`
-  &: first-child {
+  &: first-of-type {
     display: flex;
     align-items: center;
   }
 
-  &: nth-child(2) {
+  &: nth-of-type(2) {
     display: flex;
     flex-direction: column;
     padding: 4% 0 3% 3%;

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,15 +1,14 @@
+import { ImageInfo } from '@constants/carouselInfo';
 import styled from '@emotion/styled';
-import { ImageProps } from '@type/styles/image';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
 interface CarouselProps {
-  title: string;
-  images: ImageProps[];
+  images: ImageInfo[];
 }
 
-const Carousel = ({ title, images }: CarouselProps) => {
+const Carousel = ({ images }: CarouselProps) => {
   const settings = {
     dots: true,
     slidesToShow: 1,
@@ -21,22 +20,32 @@ const Carousel = ({ title, images }: CarouselProps) => {
 
   return (
     <CarouselContainer>
-      <h2>{title}</h2>
       <Slider {...settings}>
         {images.map((image, index) => (
-          <div key={index}>
-            <img src={image.src} />
-          </div>
+          <>
+            <SliderWrapper
+              key={index}
+              onClick={() => window.open(image.link, '_blank')}
+            >
+              <img src={image.src} width="100%" height={200} />
+            </SliderWrapper>
+            {image.title}
+          </>
         ))}
       </Slider>
     </CarouselContainer>
   );
 };
 
+export default Carousel;
+
 const CarouselContainer = styled.div`
+  padding: 1rem 0 1rem;
   width: 100%;
   margin: 0 auto;
-  padding: 30px;
 `;
 
-export default Carousel;
+const SliderWrapper = styled.div`
+  overflow: hidden;
+  padding-bottom: 10px;
+`;

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -21,16 +21,13 @@ const Carousel = ({ images }: CarouselProps) => {
   return (
     <CarouselContainer>
       <Slider {...settings}>
-        {images.map((image, index) => (
-          <>
-            <SliderWrapper
-              key={index}
-              onClick={() => window.open(image.link, '_blank')}
-            >
+        {images.map((image) => (
+          <div key={image.src}>
+            <SliderWrapper onClick={() => window.open(image.link, '_blank')}>
               <img src={image.src} width="100%" height={200} />
             </SliderWrapper>
             {image.title}
-          </>
+          </div>
         ))}
       </Slider>
     </CarouselContainer>

--- a/src/constants/carouselInfo.ts
+++ b/src/constants/carouselInfo.ts
@@ -1,0 +1,36 @@
+export interface ImageInfo {
+  src: string;
+  link: string;
+  title: string;
+}
+
+interface CarouselInfo {
+  title: string;
+  images: ImageInfo[];
+}
+
+export const carouselInfo: CarouselInfo = {
+  title: '웨일비',
+  images: [
+    {
+      src: 'https://whalebe.pknu.ac.kr/upload/program/2023/08/21/ce5f5595-90b9-4b1d-a432-cde4bf263abd.jpg',
+      link: 'https://whalebe.pknu.ac.kr/main/65?action=get&yy=2023&shtm=U0003002&nonsubjcCd=N202308007&nonsubjcCrsCd=C202308002',
+      title: '슬기로운 부경생활 에세이 공모전',
+    },
+    {
+      src: 'https://whalebe.pknu.ac.kr/upload/program/2023/05/03/2938c88f-046d-478a-baa8-17598303b87f.png',
+      link: 'https://whalebe.pknu.ac.kr/main/65?action=get&yy=2023&shtm=U0003001&nonsubjcCd=N202305004&nonsubjcCrsCd=C202108005',
+      title: '맞춤형 진로·취업 상담',
+    },
+    {
+      src: 'https://whalebe.pknu.ac.kr/upload/program/2023/08/22/64f7e85a-1504-4e51-96d2-24275ba82579.png',
+      link: 'https://whalebe.pknu.ac.kr/main/65?action=get&yy=2023&shtm=U0003001&nonsubjcCd=N202308022&nonsubjcCrsCd=C201900053',
+      title: '산업체현장견학',
+    },
+    {
+      src: 'https://whalebe.pknu.ac.kr/images/front/program_defult_0.png',
+      link: 'https://whalebe.pknu.ac.kr/main/65?action=get&yy=2023&shtm=U0003002&nonsubjcCd=N202308028&nonsubjcCrsCd=C202308005',
+      title: '메타버스 경진대회',
+    },
+  ],
+};

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -2,6 +2,18 @@ import '@testing-library/jest-dom';
 
 import { server } from './mocks/server';
 
+window.matchMedia =
+  window.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      addListener: function () {},
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      removeListener: function () {},
+    };
+  };
+
 jest.mock('@config/index', () => {
   return {
     SERVER_URL: 'http://localhost:8080',

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -48,7 +48,7 @@ const Home = () => {
       </InformCardWrapper>
       <InformCardWrapper>
         <InformTitle>비교과</InformTitle>
-        <Carousel title={carouselInfo.title} images={carouselInfo.images} />
+        <Carousel images={carouselInfo.images} />
       </InformCardWrapper>
     </Container>
   );

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,5 +1,7 @@
 import http from '@apis/http';
 import InformCard from '@components/Card/InformCard';
+import Carousel from '@components/Carousel';
+import { carouselInfo } from '@constants/carouselInfo';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
 import useRouter from '@hooks/useRouter';
@@ -44,6 +46,10 @@ const Home = () => {
           onClick={() => routerToGraduationRequiredPage(graduationLink)}
         />
       </InformCardWrapper>
+      <InformCardWrapper>
+        <InformTitle>비교과</InformTitle>
+        <Carousel title={carouselInfo.title} images={carouselInfo.images} />
+      </InformCardWrapper>
     </Container>
   );
 };
@@ -68,7 +74,8 @@ const InformCardWrapper = styled.div`
 `;
 
 const InformTitle = styled.div`
-  font-size: 25px;
+  font-size: 20px;
+  font-weight: bold;
 `;
 
 interface GraduationLink {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4190,6 +4190,11 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -4327,6 +4332,13 @@ idb@^7.0.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/idb/-/idb-7.1.1.tgz#d910ded866d32c7ced9befc5bfdf36f572ced72b"
   integrity sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.13:
   version "1.2.1"


### PR DESCRIPTION
## 🤠 개요

- closes: #84 
- 바뀐 홈 화면과 같은 방식으로 캐러셀을 추가했어요
- 현재 캐러셀의 내용은 서버에서 가져오는 것이 아닌 하드코딩 되어있어요!
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
--PC 화면--
<img width="1830" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/2e5a4e57-b9d4-487b-860b-d579c7ae256b">
--모바일 화면--
![IMG_556C1A2B4603-1](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/c0caa9c1-fd10-4415-b3f6-4b4e9e589b50)
