### PR TITLE
Fix/#203: 공지사항, 학과선택 페이지 스타일 버그 수정

### DIFF
--- a/src/components/List/CollegeList/CollegeItem.tsx
+++ b/src/components/List/CollegeList/CollegeItem.tsx
@@ -46,6 +46,6 @@ const ListWrapper = styled.div`
 
   width: 90%;
   margin: 0 auto;
-  padding: 8% 6% 8% 6%;
+  padding: 8% 4% 8% 4%;
   border-bottom: 1px solid ${THEME.BUTTON.GRAY};
 `;

--- a/src/components/List/CollegeList/index.tsx
+++ b/src/components/List/CollegeList/index.tsx
@@ -8,14 +8,19 @@ import CollegeSkeleton from '../Skeleton/college';
 
 const CollegeList = () => {
   return (
-    <>
+    <ListContainer>
       <Title>단과대 선택하기</Title>
       <Suspense fallback={<CollegeSkeleton length={10} />}>
         <CollegeItem resource={fetchMajorList<string[]>()} />
       </Suspense>
-    </>
+    </ListContainer>
   );
 };
+
+const ListContainer = styled.div`
+  padding-top: 2%;
+  padding-left: 2%;
+`;
 
 const Title = styled.h2`
   font-size: 24px;

--- a/src/components/List/DepartmentList/DepartmentItem.tsx
+++ b/src/components/List/DepartmentList/DepartmentItem.tsx
@@ -105,7 +105,7 @@ const ListWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  padding: 6% 4% 6% 4%;
+  padding: 8% 4% 8% 4%;
   width: 90%;
   margin: 0 auto;
   border-bottom: 1px solid ${THEME.BUTTON.GRAY};

--- a/src/components/List/DepartmentList/index.tsx
+++ b/src/components/List/DepartmentList/index.tsx
@@ -11,7 +11,7 @@ import DepartmentSkeleton from '../Skeleton/department';
 const DepartmentList = () => {
   const { college } = useParams();
   return (
-    <>
+    <ListContainer>
       <Title>학과 선택하기</Title>
       <Suspense
         fallback={
@@ -20,9 +20,16 @@ const DepartmentList = () => {
       >
         <DepartmentItem resource={fetchMajorList<string[]>(college)} />
       </Suspense>
-    </>
+    </ListContainer>
   );
 };
+
+const ListContainer = styled.div`
+  padding-top: 2%;
+  padding-left: 2%;
+  padding-bottom: 15%;
+  overflow: auto;
+`;
 
 const Title = styled.h2`
   font-size: 24px;

--- a/src/components/List/Skeleton/college.tsx
+++ b/src/components/List/Skeleton/college.tsx
@@ -27,7 +27,7 @@ const ListWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  padding: 8% 6% 8% 6%;
+  padding: 8% 4% 8% 4%;
   width: 90%;
   margin: 0 auto;
   border-bottom: 1px solid ${THEME.BUTTON.GRAY};

--- a/src/components/List/Skeleton/department.tsx
+++ b/src/components/List/Skeleton/department.tsx
@@ -38,7 +38,7 @@ const ListWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  padding: 8% 6% 8% 6%;
+  padding: 8% 4% 8% 4%;
   width: 90%;
   margin: 0 auto;
   border-bottom: 1px solid ${THEME.BUTTON.GRAY};

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -55,13 +55,13 @@ const Announcement = () => {
   };
 
   return (
-    <>
+    <Container>
       <div
         css={css`
-          width: inherit;
+          width: 100%;
           display: flex;
           position: relative;
-          overflow-x: hidden;
+          overflow-x: none;
         `}
       >
         <Button
@@ -95,11 +95,15 @@ const Announcement = () => {
           />
         </Suspense>
       </AnnounceContainer>
-    </>
+    </Container>
   );
 };
 
 export default Announcement;
+
+const Container = styled.div`
+  overflow-x: hidden;
+`;
 
 const BottomBar = styled.span<{ getAnimationType: GetAnimationType }>`
   position: absolute;
@@ -114,6 +118,7 @@ const BottomBar = styled.span<{ getAnimationType: GetAnimationType }>`
 
 const AnnounceContainer = styled.div<{ getAnimationType: GetAnimationType }>`
   width: 100%;
+  overflow: hidden;
   animation: ${({ getAnimationType }) => getAnimationType('announce')} 0.3s
     forwards;
 `;
@@ -139,7 +144,6 @@ const BottomBarSlideLeft = keyframes`
 const AnnounceSlideRight = keyframes`
   from {
     transform: translateX(-100%);
-    display: none;
   }
   to {
     transform: translateX(0%);
@@ -148,8 +152,7 @@ const AnnounceSlideRight = keyframes`
 
 const AnnounceSlideLeft = keyframes`
   from {
-    transform: translateX(200%);
-    display: none;
+    transform: translateX(100%);
   }
   to {
     transform: translateX(0%);


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
- closes : #203 
- 학과 -> 학교 애니메이션 발생 후, 모바일 뷰포트가 커졌던 스타일 버그를 해결했어요
  - 페이지에서 가장 최상위 부모 `div`에 `overflow-x:hidden`을 걸어서 해결했어요
- 단과대 선택 페이지에서 뷰포트가 움직였던 버그를 해결했어요
  - `padding` 관련 문제라 크기를 줄였어요
- 학과 선택 페이지에서 선택완료 버튼 뒤에 학과가 있던 스타일 버그를 해결했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
