### PR TITLE
Fix/#207: 부리미 -> 부림이로 롤백 및 헤더 수정

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "부리미",
-  "short_name": "부리미",
+  "name": "부림이",
+  "short_name": "부림이",
   "start_url": "/",
   "display": "fullscreen",
   "background_color": "#ffffff",

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,5 @@
 import Icon from '@components/Icon';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useRoter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
@@ -9,8 +10,12 @@ const Header = () => {
     <HeaderContainer>
       <HeaderWrapper>
         <Icon kind="arrowBack" onClick={goBack} />
-        <Logo onClick={() => routerTo('/')}>burimi</Logo>
-        <div></div>
+        <Logo onClick={() => routerTo('/')}>부림이</Logo>
+        <div
+          css={css`
+            width: 28px;
+          `}
+        ></div>
         {/* <Icon kind="menu" /> */}
       </HeaderWrapper>
     </HeaderContainer>


### PR DESCRIPTION
## 🤠 개요

- closes: #207 
- 헤더 burimi를 한글 부림이로 변경했어요
- 부림이를 헤더 정 중앙에 배치하도록 했어요
- 한글이 이쁜지 영어가 이쁜지는 잘 모르겠어요.. ㅎㅎ
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
--before--
<img width="487" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/108694d5-3ca2-472d-8e6e-82162b7553e5">
--after--
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/9d9630a1-ee6b-4118-88c6-737f2e17edfb)
