### PR TITLE
Fix: 캐러셀 클릭 시 웨일비 홈으로 이동하도록 변경

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -22,8 +22,13 @@ const Carousel = ({ images }: CarouselProps) => {
     <CarouselContainer>
       <Slider {...settings}>
         {images.map((image) => (
-          <div key={image.src}>
-            <SliderWrapper onClick={() => window.open(image.link, '_blank')}>
+          <div
+            key={image.src}
+            onClick={() =>
+              window.open('https://whalebe.pknu.ac.kr/main', '_blank')
+            }
+          >
+            <SliderWrapper>
               <img src={image.src} width="100%" height={200} />
             </SliderWrapper>
             {image.title}
@@ -40,6 +45,9 @@ const CarouselContainer = styled.div`
   padding: 1rem 0 1rem;
   width: 100%;
   margin: 0 auto;
+  &: hover {
+    cursor: pointer;
+  }
 `;
 
 const SliderWrapper = styled.div`


### PR DESCRIPTION
## 🤠 개요

- closes: #211 
- 캐러셀 클릭 시 웨일비 홈화면으로 이동하도록 수정했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
