### PR TITLE
Feat: push 알림 클릭 시 본인 학과 공지사항 페이지로 이동하도록 추가

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -20,3 +20,14 @@ self.addEventListener('push', (e) => {
     icon: data.icon,
   });
 });
+
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close(); // 알림 닫기
+  const major = event.notification.title.split(' ')[0];
+
+  event.waitUntil(
+    self.clients.openWindow(
+      'https://main.d1xmrqbiduo1fa.amplifyapp.com/announcement/' + major,
+    ),
+  );
+});


### PR DESCRIPTION
## 🤠 개요

- push 알림 클릭 시 본인 학과 공지사항 페이지로 이동하도록 추가했어요
- 대신 아래 스크린샷과 같이 바로 URL 을 통해 들어가니까 border-bottom 에러가 있어요
- 어떻게 border-bottom 이 설정되어있는지 몰라서 수정은 못했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="516" alt="Screenshot 2023-09-03 at 9 29 07 AM" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/b8902a87-2f1d-4a78-bf3e-eeb0e68db968">
