### PR TITLE
Refactor/#210: 모달 state, dispatch 컨텍스트 분리

### DIFF
--- a/src/@types/modals.ts
+++ b/src/@types/modals.ts
@@ -1,8 +1,8 @@
-import { FunctionComponent } from 'react';
+import { modals } from '@hooks/useModals';
 
 export type Modals =
   | Array<{
-      Component: FunctionComponent<any>;
+      Component: (typeof modals)[keyof typeof modals];
       props: object;
     }>
   | [];

--- a/src/components/Card/InformCard/index.test.tsx
+++ b/src/components/Card/InformCard/index.test.tsx
@@ -60,13 +60,16 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('@hooks/useModals', () => {
   const modalsMock = {
-    modals: [],
     openModal: jest.fn(),
     closeModal: jest.fn(),
   };
+
+  const modalActuals = jest.requireActual('@hooks/useModals');
+
   return {
-    __esModule: true,
+    ...modalActuals,
     default: () => modalsMock,
+    modals: modalActuals.modals,
   };
 });
 

--- a/src/components/Card/InformCard/index.tsx
+++ b/src/components/Card/InformCard/index.tsx
@@ -1,15 +1,12 @@
 import Icon from '@components/Icon';
-import AlertModal from '@components/Modal/AlertModal';
-import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
-import useModals from '@hooks/useModals';
+import useModals, { modals } from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { IconKind } from '@type/styles/icon';
-
-// TODO: InformCard 컴포넌트 Props 및 로직 수정
 
 interface InformCardProps {
   icon: IconKind & ('school' | 'notification');
@@ -34,13 +31,13 @@ const InformCard = ({
       onClick();
       return;
     }
-    openModal(AlertModal, {
+    openModal<typeof modals.alert>(modals.alert, {
       message: MODAL_MESSAGE.ALERT.SET_MAJOR,
-      buttonMessage: '전공선택하러 가기',
+      buttonMessage: MODAL_BUTTON_MESSAGE.SET_MAJOR,
       iconKind: 'plus',
-      onClose: () => closeModal(AlertModal),
+      onClose: () => closeModal(modals.alert),
       routerTo: () => {
-        closeModal(AlertModal);
+        closeModal(modals.alert);
         routerToMajorDecision();
       },
     });
@@ -91,33 +88,31 @@ export default InformCard;
 
 const Card = styled.div`
   display: flex;
-  flexdirection: row;
+  flex-direction: row;
   padding: 3% 1% 2% 0;
-
-  color: THEME.TEXT.GRAY;
-
+  color: ${THEME.TEXT.GRAY};
   height: 70px;
 
-  & > svg: {
+  & > svg {
     margin: 10px 0;
   }
   cursor: pointer;
 
   transition: all 0.2s ease-in-out;
 
-  &: active {
+  &:active {
     transform: scale(0.95);
     opacity: 0.6;
   }
 `;
 
 const Wrapper = styled.div`
-  &: first-of-type {
+  &:first-of-type {
     display: flex;
     align-items: center;
   }
 
-  &: nth-of-type(2) {
+  &:nth-of-type(2) {
     display: flex;
     flex-direction: column;
     padding: 4% 0 3% 3%;

--- a/src/components/List/DepartmentList/DepartmentItem.tsx
+++ b/src/components/List/DepartmentList/DepartmentItem.tsx
@@ -2,7 +2,7 @@ import http from '@apis/http';
 import Button from '@components/Button';
 import Icon from '@components/Icon';
 import { SERVER_URL } from '@config/index';
-import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
@@ -56,7 +56,7 @@ const DepartmentItem = ({ resource }: DepartmentItemProps) => {
 
     openModal<typeof modals.alert>(modals.alert, {
       message: MODAL_MESSAGE.SUCCEED.SET_MAJOR,
-      buttonMessage: '홈으로 이동하기',
+      buttonMessage: MODAL_BUTTON_MESSAGE.GO_HOME,
       onClose: () => routerToHome(),
       routerTo: () => routerToHome(),
     });

--- a/src/components/List/DepartmentList/DepartmentItem.tsx
+++ b/src/components/List/DepartmentList/DepartmentItem.tsx
@@ -1,14 +1,12 @@
 import http from '@apis/http';
 import Button from '@components/Button';
 import Icon from '@components/Icon';
-import AlertModal from '@components/Modal/AlertModal';
-import ConfirmModal from '@components/Modal/ConfirmModal';
 import { SERVER_URL } from '@config/index';
 import { MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
-import useModals from '@hooks/useModals';
+import useModals, { modals } from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { AxiosError, AxiosResponse } from 'axios';
@@ -33,7 +31,7 @@ const DepartmentItem = ({ resource }: DepartmentItemProps) => {
   const [buttonDisable, setButtonDisable] = useState<boolean>(true);
 
   const routerToHome = () => {
-    closeModal(AlertModal);
+    closeModal(modals.alert);
     routerTo('/');
   };
   const handleMajorClick: React.MouseEventHandler<HTMLElement> = (e) => {
@@ -43,7 +41,7 @@ const DepartmentItem = ({ resource }: DepartmentItemProps) => {
   };
 
   const handlerMajorSetModal = () => {
-    closeModal(ConfirmModal);
+    closeModal(modals.confirm);
 
     const storedSubscribe = localStorage.getItem('subscribe');
     if (major && storedSubscribe) {
@@ -56,7 +54,7 @@ const DepartmentItem = ({ resource }: DepartmentItemProps) => {
     localStorage.setItem('major', afterSpace);
     setMajor(afterSpace);
 
-    openModal(AlertModal, {
+    openModal<typeof modals.alert>(modals.alert, {
       message: MODAL_MESSAGE.SUCCEED.SET_MAJOR,
       buttonMessage: '홈으로 이동하기',
       onClose: () => routerToHome(),
@@ -64,10 +62,10 @@ const DepartmentItem = ({ resource }: DepartmentItemProps) => {
     });
   };
   const handleMajorConfirmModal = () => {
-    openModal(ConfirmModal, {
+    openModal<typeof modals.confirm>(modals.confirm, {
       message: MODAL_MESSAGE.CONFIRM.SET_MAJOR,
       onConfirmButtonClick: () => handlerMajorSetModal(),
-      onCancelButtonClick: () => closeModal(ConfirmModal),
+      onCancelButtonClick: () => closeModal(modals.confirm),
     });
   };
 

--- a/src/components/Modal/Modals/index.tsx
+++ b/src/components/Modal/Modals/index.tsx
@@ -1,14 +1,15 @@
-import useModals from '@hooks/useModals';
-import React from 'react';
+import ModalContext from '@contexts/modals';
+import React, { Fragment, useContext } from 'react';
 
 const Modals = () => {
-  const { modals } = useModals();
+  const modals = useContext(ModalContext.ModalState);
 
   return (
     <>
-      {modals.map(({ Component, props }, idx) => {
-        return <Component key={idx} {...props} />;
-      })}
+      {modals &&
+        modals.map(({ Component, props }, idx) => {
+          return <Component key={idx} {...(props as any)} />;
+        })}
     </>
   );
 };

--- a/src/components/Modal/SuggestionModal/index.tsx
+++ b/src/components/Modal/SuggestionModal/index.tsx
@@ -2,7 +2,7 @@ import http from '@apis/http';
 import Button from '@components/Button';
 import Icon from '@components/Icon';
 import { SERVER_URL } from '@config/index';
-import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useModals, { modals } from '@hooks/useModals';
@@ -47,7 +47,7 @@ const SuggestionModal = ({
     closeModal(modals.confirm);
     openModal<typeof modals.alert>(modals.alert, {
       message: MODAL_MESSAGE.SUCCEED.POST_SUGGESTION,
-      buttonMessage: '확인',
+      buttonMessage: MODAL_BUTTON_MESSAGE.CONFIRM,
       onClose: () => closeModal(modals.alert),
     });
   };

--- a/src/components/Modal/SuggestionModal/index.tsx
+++ b/src/components/Modal/SuggestionModal/index.tsx
@@ -5,14 +5,12 @@ import { SERVER_URL } from '@config/index';
 import { MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import useModals from '@hooks/useModals';
+import useModals, { modals } from '@hooks/useModals';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { areaResize } from '@utils/styles/textarea-resize';
 import React, { useRef, useState } from 'react';
 
 import Modal from '..';
-import AlertModal from '../AlertModal';
-import ConfirmModal from '../ConfirmModal';
 
 interface SuggestionModalProps {
   title: string;
@@ -46,19 +44,19 @@ const SuggestionModal = ({
   const handleSuggestionPostModal = () => {
     postSuggestion();
     onClose();
-    closeModal(ConfirmModal);
-    openModal(AlertModal, {
+    closeModal(modals.confirm);
+    openModal<typeof modals.alert>(modals.alert, {
       message: MODAL_MESSAGE.SUCCEED.POST_SUGGESTION,
       buttonMessage: '확인',
-      onClose: () => closeModal(AlertModal),
+      onClose: () => closeModal(modals.alert),
     });
   };
 
   const handleSuggestionConfirmModal = () => {
-    openModal(ConfirmModal, {
+    openModal(modals.confirm, {
       message: MODAL_MESSAGE.CONFIRM.POST_SUGGESTION,
       onConfirmButtonClick: () => handleSuggestionPostModal(),
-      onCancelButtonClick: () => closeModal(ConfirmModal),
+      onCancelButtonClick: () => closeModal(modals.confirm),
     });
   };
 

--- a/src/components/ModalsProvider/index.tsx
+++ b/src/components/ModalsProvider/index.tsx
@@ -9,9 +9,11 @@ interface ModalsProviderProps {
 const ModalsProvider = ({ children }: ModalsProviderProps) => {
   const [modals, setModals] = useState<Modals>([]);
   return (
-    <ModalsContext.Provider value={{ modals, setModals }}>
-      {children}
-    </ModalsContext.Provider>
+    <ModalsContext.ModalState.Provider value={modals}>
+      <ModalsContext.ModalDispatch.Provider value={setModals}>
+        {children}
+      </ModalsContext.ModalDispatch.Provider>
+    </ModalsContext.ModalState.Provider>
   );
 };
 

--- a/src/constants/modal-messages.ts
+++ b/src/constants/modal-messages.ts
@@ -1,17 +1,37 @@
 export const MODAL_MESSAGE = {
+  SUGGESTION_TITLE: '건의사항',
   CONFIRM: {
     SET_MAJOR: '이 전공으로 선택할까요?',
     EDIT_MAJOR: '이 전공으로 수정할까요?',
     POST_SUGGESTION: '건의사항을 보내시겠어요?',
+    ALARM: '알림을 그만 받을까요?',
   },
   ALERT: {
     OVER_MAP_BOUNDARY: '앗! 지도의 영역을 벗어났어요',
     OVER_MAP_LEVEL: '앗! 더이상 지도를 축소할 수 없어요',
     SET_MAJOR: '앗! 아직 전공을 알려주지 않았어요',
+    GET_LOCATION: '위치정보를 가져오는 중입니다...',
+    NO_LOCATION_PERMISSON:
+      '위치정보를 제공하지 않아 \n길찾기 기능을 사용할 수 없어요!',
+    OUTSIDE_SCHOOL:
+      '학교 외부에 있어요!\n 길찾기 기능을 이용해주세요.\n 현재주소',
+    NO_SEARCH_KEYWORD: '검색어를 입력해주세요!',
+    SEARCH_FAILED:
+      '찾으시는 건물이 존재하지 않아요!\n 검색어를 다시 확인해주세요.',
   },
   SUCCEED: {
     SET_MAJOR: '전공 선택 완료!',
     EDIT_MAJOR: '전공 수정 완료!',
-    POST_SUGGESTION: '🙇‍♂️건의사항을 남겨 주셔서 정말 감사드립니다!🙇‍♂️',
+    POST_SUGGESTION: '건의사항을 남겨 주셔서 정말 감사드립니다!',
   },
+};
+
+export const MODAL_BUTTON_MESSAGE = {
+  YES: '네!',
+  NO: '아니오',
+  CONFIRM: '확인',
+  CLOSE: '닫기',
+  GO_HOME: '홈으로 이동하기',
+  SET_MAJOR: '전공선택하러 가기',
+  SEND_SUGGESTION: '보내기',
 };

--- a/src/contexts/modals.ts
+++ b/src/contexts/modals.ts
@@ -11,7 +11,3 @@ const ModalContext = {
 };
 
 export default ModalContext;
-
-// TODO
-// 1. modal state, modal dispatch -> context 분리
-// 2. 부림이 내부에서 사용하는 modal들의 컴포넌트 상태를 정의하고 any 사용하지 않기

--- a/src/contexts/modals.ts
+++ b/src/contexts/modals.ts
@@ -1,11 +1,17 @@
 import { Modals } from '@type/modals';
-import { createContext } from 'react';
+import { SetStateAction, createContext } from 'react';
 
-interface ModalState {
-  modals: Modals;
-  setModals: React.Dispatch<React.SetStateAction<Modals>>;
-}
+type Dispatch = React.Dispatch<SetStateAction<Modals>>;
+const ModalState = createContext<Modals | null>(null);
+const ModalDispatch = createContext<Dispatch | null>(null);
 
-const ModalsContext = createContext<ModalState | null>(null);
+const ModalContext = {
+  ModalState,
+  ModalDispatch,
+};
 
-export default ModalsContext;
+export default ModalContext;
+
+// TODO
+// 1. modal state, modal dispatch -> context 분리
+// 2. 부림이 내부에서 사용하는 modal들의 컴포넌트 상태를 정의하고 any 사용하지 않기

--- a/src/hooks/useLocationHandler.ts
+++ b/src/hooks/useLocationHandler.ts
@@ -1,18 +1,16 @@
-import AlertModal from '@components/Modal/AlertModal';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { NO_PROVIDE_LOCATION } from '@constants/pknu-map';
 import isUserInSchool from '@pages/Map/handlers/distance-handler';
 import { Location } from '@type/map';
-import { ComponentProps, FunctionComponent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { CloseModal, OpenModal, modals } from './useModals';
 import useUserLocation from './useUserLocation';
 
 type UserLocationHandler = (
   map: any,
-  openModal: (
-    Component: FunctionComponent<any>,
-    props: Omit<ComponentProps<any>, 'open'>,
-  ) => void,
-  closeModal: (Component: FunctionComponent<any>) => void,
+  openModal: OpenModal,
+  closeModal: CloseModal,
 ) => void;
 
 const hasLocationPermission = (location: Location | null) => {
@@ -46,28 +44,27 @@ const useLocationHandler: UserLocationHandler = (
   useEffect(() => {
     if (!map) return;
     if (!location) {
-      return openModal(AlertModal, {
-        message: '위치 정보를 가져오는 중입니다...',
+      return openModal<typeof modals.alert>(modals.alert, {
+        message: MODAL_MESSAGE.ALERT.GET_LOCATION,
       });
     }
-    closeModal(AlertModal);
+    closeModal(modals.alert);
 
     if (!hasLocationPermission(location)) {
-      return openModal(AlertModal, {
-        message:
-          '위치정보를 제공하지 않아 \n길찾기 기능을 이용하실 수 없습니다.',
-        buttonMessage: '닫기',
-        onClose: () => closeModal(AlertModal),
+      return openModal<typeof modals.alert>(modals.alert, {
+        message: MODAL_MESSAGE.ALERT.NO_LOCATION_PERMISSON,
+        buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,
+        onClose: () => closeModal(modals.alert),
       });
     }
 
     location && getUserRoadAddress();
     if (location && !isUserInSchool(location.LAT, location.LNG)) {
       if (roadAddress) {
-        return openModal(AlertModal, {
-          message: `학교 외부에 있어요!\n 길찾기 기능을 이용해주세요.\n 현재주소 : ${roadAddress}`,
-          buttonMessage: '닫기',
-          onClose: () => closeModal(AlertModal),
+        return openModal<typeof modals.alert>(modals.alert, {
+          message: `${MODAL_MESSAGE.ALERT.OUTSIDE_SCHOOL} : ${roadAddress}`,
+          buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,
+          onClose: () => closeModal(modals.alert),
         });
       }
     }

--- a/src/hooks/useModals.ts
+++ b/src/hooks/useModals.ts
@@ -1,3 +1,6 @@
+import AlertModal from '@components/Modal/AlertModal';
+import ConfirmModal from '@components/Modal/ConfirmModal';
+import SuggestionModal from '@components/Modal/SuggestionModal';
 import ModalsContext from '@contexts/modals';
 import {
   ComponentProps,
@@ -6,18 +9,33 @@ import {
   useContext,
 } from 'react';
 
-const useModals = () => {
-  const context = useContext(ModalsContext);
-  if (!context) {
-    throw new Error('MajorContext does not exists.');
-  }
-  const { modals, setModals } = context;
+export const modals = {
+  confirm: ConfirmModal as FunctionComponent<
+    ComponentProps<typeof ConfirmModal>
+  >,
+  alert: AlertModal as FunctionComponent<ComponentProps<typeof AlertModal>>,
+  suggestion: SuggestionModal as FunctionComponent<
+    ComponentProps<typeof SuggestionModal>
+  >,
+} as const;
 
-  const openModal = useCallback(
-    <T extends FunctionComponent<any>>(
-      Component: T,
-      props: Omit<ComponentProps<T>, 'open'>,
-    ) => {
+export type OpenModal = <T extends (typeof modals)[keyof typeof modals]>(
+  Component: T,
+  props: Omit<ComponentProps<T>, 'open'>,
+) => void;
+
+export type CloseModal = <T extends (typeof modals)[keyof typeof modals]>(
+  Component: T,
+) => void;
+
+const useModals = () => {
+  const setModals = useContext(ModalsContext.ModalDispatch);
+  if (!setModals) {
+    throw new Error('ModalContext does not exists.');
+  }
+
+  const openModal: OpenModal = useCallback(
+    (Component, props) => {
       setModals((modals) => [
         ...modals,
         { Component, props: { ...props, open: true } },
@@ -25,9 +43,8 @@ const useModals = () => {
     },
     [setModals],
   );
-
-  const closeModal = useCallback(
-    <T extends FunctionComponent<any>>(Component: T) => {
+  const closeModal: CloseModal = useCallback(
+    (Component) => {
       setModals((modals) =>
         modals.filter((modal) => modal.Component !== Component),
       );
@@ -35,7 +52,6 @@ const useModals = () => {
     [setModals],
   );
   return {
-    modals,
     openModal,
     closeModal,
   };

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -2,7 +2,7 @@ import fetchAnnounceList from '@apis/Suspense/fetch-announce-list';
 import Button from '@components/Button';
 import AnnounceList from '@components/Card/AnnounceCard/AnnounceList';
 import AnnounceCardSkeleton from '@components/Card/AnnounceCard/Skeleton';
-import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
@@ -37,7 +37,7 @@ const Announcement = () => {
     if (!major) {
       openModal<typeof modals.alert>(modals.alert, {
         message: MODAL_MESSAGE.ALERT.SET_MAJOR,
-        buttonMessage: '전공선택하러 가기',
+        buttonMessage: MODAL_BUTTON_MESSAGE.SET_MAJOR,
         iconKind: 'plus',
         onClose: () => closeModal(modals.alert),
         routerTo: () => {

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -2,12 +2,11 @@ import fetchAnnounceList from '@apis/Suspense/fetch-announce-list';
 import Button from '@components/Button';
 import AnnounceList from '@components/Card/AnnounceCard/AnnounceList';
 import AnnounceCardSkeleton from '@components/Card/AnnounceCard/Skeleton';
-import AlertModal from '@components/Modal/AlertModal';
 import { MODAL_MESSAGE } from '@constants/modal-messages';
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
-import useModals from '@hooks/useModals';
+import useModals, { modals } from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { Suspense, useState } from 'react';
@@ -36,17 +35,16 @@ const Announcement = () => {
 
   const handleMajorAnnouncements = () => {
     if (!major) {
-      openModal(AlertModal, {
+      openModal<typeof modals.alert>(modals.alert, {
         message: MODAL_MESSAGE.ALERT.SET_MAJOR,
         buttonMessage: '전공선택하러 가기',
         iconKind: 'plus',
-        onClose: () => closeModal(AlertModal),
+        onClose: () => closeModal(modals.alert),
         routerTo: () => {
-          closeModal(AlertModal);
+          closeModal(modals.alert);
           routerToMajorDecision();
         },
       });
-      return;
     }
     if (!activeAnimation) {
       setActiveAnimation((prev) => !prev);

--- a/src/pages/Map/components/MapHeader.tsx
+++ b/src/pages/Map/components/MapHeader.tsx
@@ -1,9 +1,9 @@
 import Icon from '@components/Icon';
-import AlertModal from '@components/Modal/AlertModal';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { PKNU_BUILDINGS } from '@constants/pknu-map';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import useModals from '@hooks/useModals';
+import useModals, { modals } from '@hooks/useModals';
 import useUserLocation from '@hooks/useUserLocation';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { BuildingType, Location, PKNUBuilding } from '@type/map';
@@ -52,18 +52,18 @@ const MapHeader = ({ map }: MapHeaderProps) => {
   const searchHandler = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!inputRef.current || inputRef.current.value.length < 1) {
-      return openModal(AlertModal, {
-        message: '검색어를 입력해주세요!',
-        buttonMessage: '닫기',
-        onClose: () => closeModal(AlertModal),
+      return openModal<typeof modals.alert>(modals.alert, {
+        message: MODAL_MESSAGE.ALERT.NO_SEARCH_KEYWORD,
+        buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,
+        onClose: () => closeModal(modals.alert),
       });
     }
     const searchResult = searchBuildingInfo(inputRef.current?.value);
     if (searchResult === -1) {
-      return openModal(AlertModal, {
-        message: '찾으시는 건물이 존재하지 않아요! 검색어를 다시 확인해주세요.',
-        buttonMessage: '닫기',
-        onClose: () => closeModal(AlertModal),
+      return openModal<typeof modals.alert>(modals.alert, {
+        message: MODAL_MESSAGE.ALERT.SEARCH_FAILED,
+        buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,
+        onClose: () => closeModal(modals.alert),
       });
     }
     const [buildingType, index] = searchResult;

--- a/src/pages/Map/handlers/limit-handler.ts
+++ b/src/pages/Map/handlers/limit-handler.ts
@@ -1,4 +1,4 @@
-import { MODAL_MESSAGE } from '@constants/modal-messages';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { PKNU_MAP_CENTER_LOCATION, PKNU_MAP_LIMIT } from '@constants/pknu-map';
 import { CloseModal, OpenModal, modals } from '@hooks/useModals';
 import { Location } from '@type/map';
@@ -22,7 +22,7 @@ const levelHandler: MapLimitHandler = (map, openModal, closeModal) => {
     map.setCenter(PKNU_MAP_CENTER_LOCATION);
     openModal<typeof modals.alert>(modals.alert, {
       message: MODAL_MESSAGE.ALERT.OVER_MAP_LEVEL,
-      buttonMessage: '닫기',
+      buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,
       onClose: () => closeModal(modals.alert),
     });
   };
@@ -52,7 +52,7 @@ const boundaryHandler = (
       map.setCenter(PKNU_MAP_CENTER_LOCATION);
       openModal<typeof modals.alert>(modals.alert, {
         message: MODAL_MESSAGE.ALERT.OVER_MAP_BOUNDARY,
-        buttonMessage: '닫기',
+        buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,
         onClose: () => closeModal(modals.alert),
       });
     }

--- a/src/pages/Map/handlers/limit-handler.ts
+++ b/src/pages/Map/handlers/limit-handler.ts
@@ -1,16 +1,12 @@
-import AlertModal from '@components/Modal/AlertModal';
 import { MODAL_MESSAGE } from '@constants/modal-messages';
 import { PKNU_MAP_CENTER_LOCATION, PKNU_MAP_LIMIT } from '@constants/pknu-map';
+import { CloseModal, OpenModal, modals } from '@hooks/useModals';
 import { Location } from '@type/map';
-import { ComponentProps, FunctionComponent } from 'react';
 
 type MapLimitHandler = (
   map: any,
-  openModal: (
-    Component: FunctionComponent<any>,
-    props: Omit<ComponentProps<any>, 'open'>,
-  ) => void,
-  closeModal: (Component: FunctionComponent<any>) => void,
+  openModal: OpenModal,
+  closeModal: CloseModal,
 ) => void;
 
 const levelHandler: MapLimitHandler = (map, openModal, closeModal) => {
@@ -24,10 +20,10 @@ const levelHandler: MapLimitHandler = (map, openModal, closeModal) => {
     }
     map.setLevel(PKNU_MAP_LIMIT.LEVEL);
     map.setCenter(PKNU_MAP_CENTER_LOCATION);
-    openModal(AlertModal, {
+    openModal<typeof modals.alert>(modals.alert, {
       message: MODAL_MESSAGE.ALERT.OVER_MAP_LEVEL,
       buttonMessage: '닫기',
-      onClose: () => closeModal(AlertModal),
+      onClose: () => closeModal(modals.alert),
     });
   };
   window.kakao.maps.event.addListener(map, 'zoom_changed', levelLimitHandler);
@@ -36,11 +32,8 @@ const levelHandler: MapLimitHandler = (map, openModal, closeModal) => {
 
 const boundaryHandler = (
   map: any,
-  openModal: (
-    Component: FunctionComponent<any>,
-    props: Omit<ComponentProps<any>, 'open'>,
-  ) => void,
-  closeModal: (Component: FunctionComponent<any>) => void,
+  openModal: OpenModal,
+  closeModal: CloseModal,
   location: Location | null,
 ) => {
   if (!map || !location) {
@@ -57,10 +50,10 @@ const boundaryHandler = (
     ) {
       map.setLevel(4);
       map.setCenter(PKNU_MAP_CENTER_LOCATION);
-      openModal(AlertModal, {
+      openModal<typeof modals.alert>(modals.alert, {
         message: MODAL_MESSAGE.ALERT.OVER_MAP_BOUNDARY,
         buttonMessage: '닫기',
-        onClose: () => closeModal(AlertModal),
+        onClose: () => closeModal(modals.alert),
       });
     }
   };

--- a/src/pages/Map/handlers/overlay-handler.ts
+++ b/src/pages/Map/handlers/overlay-handler.ts
@@ -1,3 +1,4 @@
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { NO_PROVIDE_LOCATION, PKNU_BUILDINGS } from '@constants/pknu-map';
 import { CloseModal, OpenModal, modals } from '@hooks/useModals';
 import { THEME } from '@styles/ThemeProvider/theme';
@@ -41,8 +42,8 @@ class NumberOverlay {
           onCancelButtonClick: () => this.closeModal(modals.confirm),
         })
       : this.openModal<typeof modals.alert>(modals.alert, {
-          message: '위치정보를 제공하지 않아 길찾기 기능을 사용할 수 없어요!',
-          buttonMessage: '닫기',
+          message: MODAL_MESSAGE.ALERT.NO_LOCATION_PERMISSON,
+          buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,
           onClose: () => this.closeModal(modals.alert),
         });
   }

--- a/src/pages/Map/handlers/overlay-handler.ts
+++ b/src/pages/Map/handlers/overlay-handler.ts
@@ -1,26 +1,18 @@
-import AlertModal from '@components/Modal/AlertModal';
-import ConfirmModal from '@components/Modal/ConfirmModal';
 import { NO_PROVIDE_LOCATION, PKNU_BUILDINGS } from '@constants/pknu-map';
+import { CloseModal, OpenModal, modals } from '@hooks/useModals';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { BuildingType, Location, PKNUBuilding } from '@type/map';
-import { ComponentProps, FunctionComponent } from 'react';
 
 class NumberOverlay {
   private PKNU_BUILDING: PKNUBuilding;
-  private openModal: (
-    Component: FunctionComponent<any>,
-    props: Omit<ComponentProps<any>, 'open'>,
-  ) => void;
-  private closeModal: (Component: FunctionComponent<any>) => void;
+  private openModal: OpenModal;
+  private closeModal: CloseModal;
   private userLocation: Location | null;
 
   constructor(
     PKNU_BUILDING: PKNUBuilding,
-    openModal: (
-      Component: FunctionComponent<any>,
-      props: Omit<ComponentProps<any>, 'open'>,
-    ) => void,
-    closeModal: (Component: FunctionComponent<any>) => void,
+    openModal: OpenModal,
+    closeModal: CloseModal,
     userLocation: Location | null,
   ) {
     this.PKNU_BUILDING = PKNU_BUILDING;
@@ -40,18 +32,18 @@ class NumberOverlay {
       : `https://map.kakao.com/link/from/내위치,${this.userLocation.LAT},${this.userLocation.LNG}/to/${buildingName},${lat},${lng}`;
 
     JSON.stringify(this.userLocation) !== JSON.stringify(NO_PROVIDE_LOCATION)
-      ? this.openModal(ConfirmModal, {
+      ? this.openModal<typeof modals.confirm>(modals.confirm, {
           message: `목적지(${buildingNumber})로 길찾기를 시작할까요?`,
           onConfirmButtonClick: () => {
             window.open(routeUrl, '_blank');
-            this.closeModal(ConfirmModal);
+            this.closeModal(modals.confirm);
           },
-          onCancelButtonClick: () => this.closeModal(ConfirmModal),
+          onCancelButtonClick: () => this.closeModal(modals.confirm),
         })
-      : this.openModal(AlertModal, {
+      : this.openModal<typeof modals.alert>(modals.alert, {
           message: '위치정보를 제공하지 않아 길찾기 기능을 사용할 수 없어요!',
           buttonMessage: '닫기',
-          onClose: () => this.closeModal(AlertModal),
+          onClose: () => this.closeModal(modals.alert),
         });
   }
 

--- a/src/pages/My/index.test.tsx
+++ b/src/pages/My/index.test.tsx
@@ -1,7 +1,6 @@
 import MajorProvider from '@components/MajorProvider';
-import SuggestionModal from '@components/Modal/SuggestionModal';
 import ModalsProvider from '@components/ModalsProvider';
-import useModals from '@hooks/useModals';
+import useModals, { modals } from '@hooks/useModals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
@@ -17,13 +16,15 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('@hooks/useModals', () => {
   const modalsMock = {
-    modals: [],
     openModal: jest.fn(),
     closeModal: jest.fn(),
   };
+  const modalsActual = jest.requireActual('@hooks/useModals');
+
   return {
-    __esModule: true,
+    ...modalsActual,
     default: () => modalsMock,
+    modals: modalsActual.modals,
   };
 });
 
@@ -45,7 +46,7 @@ describe('마이 페이지 동작 테스트', () => {
       await userEvent.click(modalButton);
     });
 
-    expect(useModals().openModal).toHaveBeenCalledWith(SuggestionModal, {
+    expect(useModals().openModal).toHaveBeenCalledWith(modals.suggestion, {
       title: '건의사항',
       buttonMessage: '보내기',
       onClose: expect.any(Function),

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -3,6 +3,7 @@ import Button from '@components/Button';
 import ToggleButton from '@components/Button/Toggle';
 import Icon from '@components/Icon';
 import { SERVER_URL } from '@config/index';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import urlBase64ToUint8Array from '@hooks/urlBase64ToUint8Array';
@@ -23,18 +24,18 @@ const My = () => {
 
   const handleSuggestionModal = () => {
     openModal<typeof modals.suggestion>(modals.suggestion, {
-      title: '건의사항',
-      buttonMessage: '보내기',
+      title: MODAL_MESSAGE.SUGGESTION_TITLE,
+      buttonMessage: MODAL_BUTTON_MESSAGE.SEND_SUGGESTION,
       onClose: () => closeModal(modals.suggestion),
     });
   };
 
   const handleSubscribeTopic: MouseEventHandler<HTMLElement> = async () => {
-    if (!animation) setAnimation(true); // 토글 버튼 클릭 애니메이션을 위해 사용
+    if (!animation) setAnimation(true);
 
     if (subscribe) {
       openModal<typeof modals.confirm>(modals.confirm, {
-        message: '알림을 그만 받을까요?',
+        message: MODAL_MESSAGE.CONFIRM.ALARM,
         onConfirmButtonClick: async () => {
           await http.delete(`${SERVER_URL}/api/subscription/major`, {
             data: { subscription: subscribe, major },
@@ -53,8 +54,8 @@ const My = () => {
     if (!('serviceWorker' in navigator)) return;
     if (!major) {
       openModal<typeof modals.alert>(modals.alert, {
-        message: '학과를 선택해주세요',
-        buttonMessage: '확인',
+        message: MODAL_MESSAGE.ALERT.SET_MAJOR,
+        buttonMessage: MODAL_BUTTON_MESSAGE.CONFIRM,
         onClose: () => closeModal(modals.alert),
         routerTo: () => {
           closeModal(modals.alert);

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -2,15 +2,12 @@ import http from '@apis/http';
 import Button from '@components/Button';
 import ToggleButton from '@components/Button/Toggle';
 import Icon from '@components/Icon';
-import AlertModal from '@components/Modal/AlertModal';
-import ConfirmModal from '@components/Modal/ConfirmModal';
-import SuggestionModal from '@components/Modal/SuggestionModal';
 import { SERVER_URL } from '@config/index';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import urlBase64ToUint8Array from '@hooks/urlBase64ToUint8Array';
 import useMajor from '@hooks/useMajor';
-import useModals from '@hooks/useModals';
+import useModals, { modals } from '@hooks/useModals';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { MouseEventHandler, useEffect, useState } from 'react';
@@ -18,36 +15,36 @@ import { MouseEventHandler, useEffect, useState } from 'react';
 const My = () => {
   const [subscribe, setSubscribe] = useState<PushSubscription | null>(null);
   const [animation, setAnimation] = useState(false);
-
   const { major } = useMajor();
   const { routerTo } = useRouter();
-  const routerToMajorDecision = () => routerTo('/major-decision');
   const { openModal, closeModal } = useModals();
 
+  const routerToMajorDecision = () => routerTo('/major-decision');
+
   const handleSuggestionModal = () => {
-    openModal(SuggestionModal, {
+    openModal<typeof modals.suggestion>(modals.suggestion, {
       title: '건의사항',
       buttonMessage: '보내기',
-      onClose: () => closeModal(SuggestionModal),
+      onClose: () => closeModal(modals.suggestion),
     });
   };
 
-  const subscribeTopic: MouseEventHandler<HTMLElement> = async () => {
+  const handleSubscribeTopic: MouseEventHandler<HTMLElement> = async () => {
     if (!animation) setAnimation(true); // 토글 버튼 클릭 애니메이션을 위해 사용
 
     if (subscribe) {
-      openModal(ConfirmModal, {
+      openModal<typeof modals.confirm>(modals.confirm, {
         message: '알림을 그만 받을까요?',
         onConfirmButtonClick: async () => {
           await http.delete(`${SERVER_URL}/api/subscription/major`, {
             data: { subscription: subscribe, major },
           });
           setSubscribe(null);
-          closeModal(ConfirmModal);
+          closeModal(modals.confirm);
           localStorage.removeItem('subscribe');
         },
         onCancelButtonClick: () => {
-          closeModal(ConfirmModal);
+          closeModal(modals.confirm);
         },
       });
       return;
@@ -55,12 +52,12 @@ const My = () => {
 
     if (!('serviceWorker' in navigator)) return;
     if (!major) {
-      openModal(AlertModal, {
+      openModal<typeof modals.alert>(modals.alert, {
         message: '학과를 선택해주세요',
         buttonMessage: '확인',
-        onClose: () => closeModal(AlertModal),
+        onClose: () => closeModal(modals.alert),
         routerTo: () => {
-          closeModal(AlertModal);
+          closeModal(modals.alert);
           routerToMajorDecision();
         },
       });
@@ -128,7 +125,7 @@ const My = () => {
             <span>학과 공지사항 알림받기</span>
             <ToggleButton
               isOn={Boolean(subscribe)}
-              changeState={subscribeTopic}
+              changeState={handleSubscribeTopic}
               animation={animation}
             />
           </CardList>


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
- closes : #222 
- 모달 state, dispatch 컨텍스트를 분리 했어요

## 💫 설명

<!--

- 현재 Pr 설명

-->

### 문제 
> 지도 페이지에서, 길찾기 기능을 사용하기 위해서 건물 번호를 클릭하는 경우 지도 페이지 전체가 리렌더링되는 문제가 발생했어요. 지도 페이지 위에 있는 건물 번호를 클릭했을 때 실행되는 이벤트 핸들러 함수는 모달의 렌더링 상태만 변경(openModal)하는 책임만 있는데 이 함수가 호출됨으로 인해서 이 책임과는 상관없는 지도 페이지 전체가 리렌더링 되는것은 굉장히 비효율적이라고 판단했어요. 추가로, 지도 페이지에서 보여주는 UI도 많고 이벤트도 많고, 상태도 적지 않기 때문에 context를 분리해줘야 겠다는 판단을 했어요!
### 해결
1. 컨텍스트의 분리
```ts
// pknu-notice-front/src/contexts/modals.ts

type Dispatch = React.Dispatch<SetStateAction<Modals>>;
const ModalState = createContext<Modals | null>(null);
const ModalDispatch = createContext<Dispatch | null>(null);

const ModalContext = {
  ModalState,
  ModalDispatch,
};
```
- 모달의 렌더링만 담당하는 컴포넌트에서는 ModalState 컨텍스트 사용
```ts
// pknu-notice-front/src/components/Modal/Modals/index.tsx

const Modals = () => {
  const modals = useContext(ModalContext.ModalState);

  return (
    <>
      {modals &&
        modals.map(({ Component, props }, idx) => {
          return <Component key={idx} {...(props as any)} />;
        })}
    </>
  );
};
```
- 모달의 렌더링 상태를 변경 시키는 useModals 커스텀 훅에서는 ModalDispatch 컨텍스트 사용
```ts
const useModals = () => {
// pknu-notice-front/src/hooks/useModals.ts

  const setModals = useContext(ModalsContext.ModalDispatch);
  if (!setModals) {
    throw new Error('ModalContext does not exists.');
  }
  //...
};
```
### 추가작업
- 추가로, 모달 메세지를 상수로 관리하기 위해서 새로운 모달 메세지들을 상수 객체에 추가했어요.
- 그리고 모달 컴포넌트들의 타입을 확실하기 지정해주기 위해서 `타입 단언(assertion)`을 사용했어요
```ts
export const modals = {
  confirm: ConfirmModal as FunctionComponent<
    ComponentProps<typeof ConfirmModal>
  >,
  alert: AlertModal as FunctionComponent<ComponentProps<typeof AlertModal>>,
  suggestion: SuggestionModal as FunctionComponent<
    ComponentProps<typeof SuggestionModal>
  >,
} as const;

export type OpenModal = <T extends (typeof modals)[keyof typeof modals]>(
  Component: T,
  props: Omit<ComponentProps<T>, 'open'>,
) => void;

export type CloseModal = <T extends (typeof modals)[keyof typeof modals]>(
  Component: T,
) => void;
```

## 📷 스크린샷 (Optional)
- 분리 전  

https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/68489467/cb974c9b-62e2-4bbe-b0ea-be52b97288e5
- 분리 후  

https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/68489467/1230dd68-3700-459a-bd52-78650f7948b0

