### PR TITLE
Style/#224: FooterTab 높이 증가

### DIFF
--- a/src/components/FooterTab/index.tsx
+++ b/src/components/FooterTab/index.tsx
@@ -2,69 +2,68 @@ import Icon from '@components/Icon';
 import styled from '@emotion/styled';
 import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
-import { IconKind } from '@type/styles/icon';
 
-const footerIcons = [
-  { kind: 'map', path: '/map' },
-  { kind: 'home', path: '/' },
-  { kind: 'accountCircle', path: '/my' },
+const footerTabs = [
+  { kind: 'map', label: '지도', path: '/map' },
+  { kind: 'home', label: '홈', path: '/' },
+  { kind: 'accountCircle', label: '마이', path: '/my' },
 ] as const;
 
 const FooterTab = () => {
   const { routerTo } = useRouter();
 
-  const handleIconClick = (kind: IconKind, path: string) => {
-    routerTo(path);
-  };
+  const isUserInPath = (path: string) => window.location.pathname === path;
 
   return (
     <Footer>
-      {footerIcons.map(({ kind, path }) => (
-        <IconContainer
+      {footerTabs.map(({ kind, label, path }) => (
+        <TabButton
           key={kind}
-          role="button"
-          onClick={() => handleIconClick(kind, path)}
+          onClick={() => routerTo(path)}
+          active={isUserInPath(path)}
         >
-          <Icon
-            key={kind}
-            kind={kind}
-            color={
-              window.location.pathname === path
-                ? THEME.PRIMARY
-                : THEME.TEXT.BLACK
-            }
-          />
-        </IconContainer>
+          <Icon kind={kind} size="24" />
+          <Label active={isUserInPath(path)}>{label}</Label>
+        </TabButton>
       ))}
     </Footer>
   );
 };
 
 const Footer = styled.div`
-  // Footer 스타일 컴포넌트 수정
-  max-width: 480px;
-  position: fixed;
-  left: 50%;
-  bottom: 0;
-  transform: translateX(-50%);
-  width: 100%;
-
-  height: 8vh;
-
   display: flex;
   justify-content: space-around;
   align-items: center;
-  z-index: 2;
-  background-color: ${THEME.TEXT.WHITE};
-  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
-`;
 
-const IconContainer = styled.div`
+  max-width: 480px;
   width: 100%;
-  text-align: center;
-  &:hover {
-    cursor: pointer;
-  }
+  height: 60px;
+  padding: 15px 0px 15px 0px;
+  background-color: ${THEME.TEXT.WHITE};
+  position: fixed;
+  bottom: 0;
+  z-index: 2;
+
+  box-shadow: 0px -2px 6px rgba(99, 99, 99, 0.2);
 `;
 
+const TabButton = styled.div<{ active: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+
+  height: 100%;
+
+  transition: color 0.3s ease;
+  color: ${({ active }) => (active ? THEME.PRIMARY : THEME.TEXT.BLACK)};
+`;
+
+const Label = styled.span<{ active: boolean }>`
+  margin-top: 4px;
+  font-size: 12px;
+
+  opacity: ${({ active }) => (active ? 1 : 0.6)};
+  transition: opacity 0.2s ease;
+`;
 export default FooterTab;

--- a/src/components/FooterTab/index.tsx
+++ b/src/components/FooterTab/index.tsx
@@ -18,6 +18,7 @@ const FooterTab = () => {
     <Footer>
       {footerTabs.map(({ kind, label, path }) => (
         <TabButton
+          role="button"
           key={kind}
           onClick={() => routerTo(path)}
           active={isUserInPath(path)}

--- a/src/components/List/DepartmentList/DepartmentItem.tsx
+++ b/src/components/List/DepartmentList/DepartmentItem.tsx
@@ -113,7 +113,7 @@ const ListWrapper = styled.div`
 
 const ButtonContainer = styled.div`
   position: fixed;
-  bottom: 4%;
+  bottom: 8%;
   z-index: 3;
   width: 80%;
   max-width: 480px;

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -56,7 +56,7 @@ const Announcement = () => {
 
   return (
     <Container>
-      <div
+      <ButtonContainer
         css={css`
           width: 100%;
           display: flex;
@@ -67,6 +67,8 @@ const Announcement = () => {
         <Button
           onClick={() => routerTo('')}
           css={css`
+            margin: 0px;
+            height: 55px;
             border-radius: 0px;
             background-color: ${THEME.TEXT.WHITE};
             color: ${isKeywordUndefined() ? THEME.PRIMARY : THEME.TEXT.BLACK};
@@ -77,6 +79,8 @@ const Announcement = () => {
         <Button
           onClick={() => handleMajorAnnouncements()}
           css={css`
+            margin: 0px;
+            height: 55px;
             border-radius: 0px;
             background-color: ${THEME.TEXT.WHITE};
             color: ${isKeywordUndefined() ? THEME.TEXT.BLACK : THEME.PRIMARY};
@@ -84,8 +88,8 @@ const Announcement = () => {
         >
           학과 공지사항
         </Button>
-        <BottomBar getAnimationType={getAnimationType} />
-      </div>
+        <ButtonBottomBar getAnimationType={getAnimationType} />
+      </ButtonContainer>
       <AnnounceContainer getAnimationType={getAnimationType}>
         <Suspense fallback={<AnnounceCardSkeleton length={30} />}>
           <AnnounceList
@@ -105,7 +109,14 @@ const Container = styled.div`
   overflow-x: hidden;
 `;
 
-const BottomBar = styled.span<{ getAnimationType: GetAnimationType }>`
+const ButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  position: relative;
+  overflow-x: none;
+`;
+
+const ButtonBottomBar = styled.span<{ getAnimationType: GetAnimationType }>`
   position: absolute;
   bottom: 0;
   left: 0;

--- a/src/pages/BodyLayout/index.tsx
+++ b/src/pages/BodyLayout/index.tsx
@@ -13,7 +13,7 @@ const BodyLayout = () => {
 export default BodyLayout;
 
 const StyledBodyLayout = styled.div`
-  height: calc(100vh - 17vh);
-  padding: 8.5vh 0 8.5vh 0;
+  height: calc(100vh - 8vh - 90px);
+  padding: 8vh 0 8vh 0;
   overflow-y: scroll;
 `;

--- a/src/pages/Map/index.tsx
+++ b/src/pages/Map/index.tsx
@@ -64,7 +64,8 @@ const Container = styled.section`
 `;
 
 const KakaoMap = styled.div`
-  height: 100%;
+  height: calc(100vh - 8vh - 90px);
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
   width: 100%;
-  border-radius: 15px;
 `;


### PR DESCRIPTION
## 🤠 개요

- FooterTab 높이를 증가 시켰습니다
- [apple human interface](https://developer.apple.com/design/human-interface-guidelines)를 참고하려고 했는데, Tab내부에서 사용해야 할 아이콘의 적절한 크기 및 어떤 상황에서 어떻게 사용하면 좋을지에 대한 지침만 있어서 [PWA Today](https://whatpwacando.today/)참고해서 스타일을 변경했어요

## 💫 설명


## 📷 스크린샷 (Optional)
- 변경 전
<img width='400px' height='900px' src='https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/68489467/15134d90-c95e-4549-9eec-26594ab6fb7c' />

- 변경 후
<img width='400px' height='900px' src='https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/68489467/503fe6b0-18fa-4622-903e-50ff0d658b82' />

