### PR TITLE
Style/#227: 건물번호 검색 Input Element를 지도위에 위치하도록 설정

### DIFF
--- a/src/pages/Map/components/MapHeader.tsx
+++ b/src/pages/Map/components/MapHeader.tsx
@@ -98,14 +98,10 @@ const MapHeader = ({ map }: MapHeaderProps) => {
           type="text"
           placeholder="건물번호 또는 건물이름을 검색해주세요"
         />
-        <button
-          css={css`
-            background-color: transparent;
-          `}
-          onClick={() => searchHandler}
-        >
-          <Icon kind="search" color={THEME.PRIMARY} />
-        </button>
+        <StyledButton onClick={() => searchHandler}>
+          <Icon kind="search" size="24" color={THEME.TEXT.WHITE} />
+          <StyledText>Search</StyledText>
+        </StyledButton>
       </StyledForm>
     </HeaderContainer>
   );
@@ -114,36 +110,59 @@ const MapHeader = ({ map }: MapHeaderProps) => {
 export default memo(MapHeader);
 
 const HeaderContainer = styled.div`
-  height: 8vh;
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 100%;
+  position: absolute;
+  top: 10px;
+  z-index: 3;
 `;
 
 const StyledForm = styled.form`
   width: 100%;
-
   display: flex;
-  justify-content: center;
+  justify-content: space-around;
   align-items: center;
 `;
 
 const StyledInput = styled.input`
-  border: 0;
-  border-bottom: 2px solid ${THEME.TEXT.GRAY};
-  background-color: transparent;
-  border-radius: 0px;
+  -webkit-appearance: none;
+  appearance: none;
 
+  width: 75%;
+  padding: 10px;
+  border: 0;
+  border-radius: 5px;
+  background-color: ${THEME.TEXT.WHITE};
   font-size: 14px;
-  width: 60%;
+  text-indent: 5px;
 
   &::placeholder {
     color: ${THEME.TEXT.GRAY};
     font-size: 14px;
+    font-weight: bold;
   }
-
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
   &:focus {
-    border-bottom: 2px solid ${THEME.PRIMARY};
     outline: none;
+    box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3);
   }
+`;
+
+const StyledButton = styled.button`
+  background-color: ${THEME.PRIMARY};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 5px;
+  height: 42px;
+  width: 42px;
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.3);
+`;
+
+const StyledText = styled.span`
+  font-size: 10px;
+  color: ${THEME.TEXT.WHITE};
 `;

--- a/src/pages/Map/index.tsx
+++ b/src/pages/Map/index.tsx
@@ -61,11 +61,10 @@ const Container = styled.section`
   height: calc(100vh - 8vh);
   display: flex;
   flex-direction: column;
+  position: relative;
 `;
 
 const KakaoMap = styled.div`
-  height: calc(100vh - 8vh - 90px);
-  border-top-left-radius: 15px;
-  border-top-right-radius: 15px;
+  height: calc(100vh - 90px);
   width: 100%;
 `;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

--> 
- closes : #227 
- 건물번호, 건물이름으로 검색을 하기 위한 input Element를 지도 위에 올렸어요

## 💫 설명

<!--

- 현재 Pr 설명

-->
- input, button의 입체감을 주기 위해서`box-shadow`를 사용했는데 ios 기기에는 input에 `box-shadow`가 적용이 되지 않는 문제가 발생했어요.
```css
-webkit-appearance: none;
  appearance: none;
```
이 속성을 추가해줌으로써 문제를 해결하긴 했는데, 안드로이드 기기에서 `box-shadow`가 정상적으로 적용이 되는지는 따로 확인을 해봐야할 것 같아요
### 해결하면 좋을 이슈
실제 카카오맵 앱에서는 아이폰의 m자탈모(?)부분에도 지도가 표시가 되는데, 부림이는 m자를 제외한 사각형에만 지도가 표시가 돼요. 부림이도 실제 카카오맵 앱 처럼 보여주고 싶은데 방법을 잘 모르겠네요,,검색해도 잘 나오지 않아서 슬퍼요

## 📷 스크린샷 (Optional)
<img src='https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/68489467/dcb6af45-bc5a-4ce5-a1f8-3b17d3f6bb33' width='400px' height='800px' />

