### PR TITLE
Feat/#245: 알림 설정에 모달창으로 정보 추가

### DIFF
--- a/src/components/Modal/ConfirmModal/index.tsx
+++ b/src/components/Modal/ConfirmModal/index.tsx
@@ -29,6 +29,7 @@ const ConfirmModal = ({
                 font-weight: bold;
                 margin: 0 auto;
                 margin-bottom: 15px;
+                white-space: pre-line;
               `}
             >
               {message}

--- a/src/constants/modal-messages.ts
+++ b/src/constants/modal-messages.ts
@@ -18,6 +18,8 @@ export const MODAL_MESSAGE = {
     NO_SEARCH_KEYWORD: '검색어를 입력해주세요!',
     SEARCH_FAILED:
       '찾으시는 건물이 존재하지 않아요!\n 검색어를 다시 확인해주세요.',
+    FAIL_SUBSCRIBE_NOTI:
+      '에러가 발생했어요.. 부림이 개발자가 빨리 고쳐볼게요!\n\n 추가 건의사항이 있다면 마이페이지 -> 건의사항 남기기에 남겨주세요',
   },
   SUCCEED: {
     SET_MAJOR: '전공 선택 완료!',
@@ -34,4 +36,8 @@ export const MODAL_BUTTON_MESSAGE = {
   GO_HOME: '홈으로 이동하기',
   SET_MAJOR: '전공선택하러 가기',
   SEND_SUGGESTION: '보내기',
+};
+
+export const MODAL_NOTI_MESSAGE = (major: string) => {
+  return `9시부터 18시 사이 ${major}의 새로운 공지사항이 올라오면 푸시 알림을 받을까요?`;
 };

--- a/src/constants/modal-messages.ts
+++ b/src/constants/modal-messages.ts
@@ -4,7 +4,9 @@ export const MODAL_MESSAGE = {
     SET_MAJOR: '이 전공으로 선택할까요?',
     EDIT_MAJOR: '이 전공으로 수정할까요?',
     POST_SUGGESTION: '건의사항을 보내시겠어요?',
-    ALARM: '알림을 그만 받을까요?',
+    STOP_ALARM: '알림을 그만 받을까요?',
+    GET_ALARM:
+      '알림은 9시부터 18시 사이에 보내드려요!\n새로운 공지사항이 올라오면 푸시 알림을 받을까요?',
   },
   ALERT: {
     OVER_MAP_BOUNDARY: '앗! 지도의 영역을 벗어났어요',
@@ -36,8 +38,4 @@ export const MODAL_BUTTON_MESSAGE = {
   GO_HOME: '홈으로 이동하기',
   SET_MAJOR: '전공선택하러 가기',
   SEND_SUGGESTION: '보내기',
-};
-
-export const MODAL_NOTI_MESSAGE = (major: string) => {
-  return `9시부터 18시 사이 ${major}의 새로운 공지사항이 올라오면 푸시 알림을 받을까요?`;
 };

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -3,11 +3,7 @@ import Button from '@components/Button';
 import ToggleButton from '@components/Button/Toggle';
 import Icon from '@components/Icon';
 import { SERVER_URL } from '@config/index';
-import {
-  MODAL_BUTTON_MESSAGE,
-  MODAL_MESSAGE,
-  MODAL_NOTI_MESSAGE,
-} from '@constants/modal-messages';
+import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import urlBase64ToUint8Array from '@hooks/urlBase64ToUint8Array';
@@ -62,22 +58,9 @@ const My = () => {
       return;
     }
 
-    openModal<typeof modals.confirm>(modals.confirm, {
-      message: MODAL_NOTI_MESSAGE(major),
-      onConfirmButtonClick: () => {
-        closeModal(modals.confirm);
-        handleSubscribeTopic();
-      },
-      onCancelButtonClick: () => closeModal(modals.confirm),
-    });
-  };
-
-  const handleSubscribeTopic = async () => {
-    if (!animation) setAnimation(true);
-
     if (subscribe) {
       openModal<typeof modals.confirm>(modals.confirm, {
-        message: MODAL_MESSAGE.CONFIRM.ALARM,
+        message: MODAL_MESSAGE.CONFIRM.STOP_ALARM,
         onConfirmButtonClick: async () => {
           await http.delete(`${SERVER_URL}/api/subscription/major`, {
             data: { subscription: subscribe, major },
@@ -92,6 +75,19 @@ const My = () => {
       });
       return;
     }
+
+    openModal<typeof modals.confirm>(modals.confirm, {
+      message: MODAL_MESSAGE.CONFIRM.GET_ALARM,
+      onConfirmButtonClick: () => {
+        closeModal(modals.confirm);
+        handleSubscribeTopic();
+      },
+      onCancelButtonClick: () => closeModal(modals.confirm),
+    });
+  };
+
+  const handleSubscribeTopic = async () => {
+    if (!animation) setAnimation(true);
 
     if (!('serviceWorker' in navigator)) {
       postSuggestion();

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -3,7 +3,11 @@ import Button from '@components/Button';
 import ToggleButton from '@components/Button/Toggle';
 import Icon from '@components/Icon';
 import { SERVER_URL } from '@config/index';
-import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
+import {
+  MODAL_BUTTON_MESSAGE,
+  MODAL_MESSAGE,
+  MODAL_NOTI_MESSAGE,
+} from '@constants/modal-messages';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import urlBase64ToUint8Array from '@hooks/urlBase64ToUint8Array';
@@ -30,7 +34,31 @@ const My = () => {
     });
   };
 
-  const handleSubscribeTopic: MouseEventHandler<HTMLElement> = async () => {
+  const handleNotiModal: MouseEventHandler = () => {
+    if (!major) {
+      openModal<typeof modals.alert>(modals.alert, {
+        message: MODAL_MESSAGE.ALERT.SET_MAJOR,
+        buttonMessage: MODAL_BUTTON_MESSAGE.CONFIRM,
+        onClose: () => closeModal(modals.alert),
+        routerTo: () => {
+          closeModal(modals.alert);
+          routerToMajorDecision();
+        },
+      });
+      return;
+    }
+
+    openModal<typeof modals.confirm>(modals.confirm, {
+      message: MODAL_NOTI_MESSAGE(major),
+      onConfirmButtonClick: () => {
+        closeModal(modals.confirm);
+        handleSubscribeTopic();
+      },
+      onCancelButtonClick: () => closeModal(modals.confirm),
+    });
+  };
+
+  const handleSubscribeTopic = async () => {
     if (!animation) setAnimation(true);
 
     if (subscribe) {
@@ -51,16 +79,11 @@ const My = () => {
       return;
     }
 
-    if (!('serviceWorker' in navigator)) return;
-    if (!major) {
+    if (!('serviceWorker' in navigator)) {
       openModal<typeof modals.alert>(modals.alert, {
-        message: MODAL_MESSAGE.ALERT.SET_MAJOR,
-        buttonMessage: MODAL_BUTTON_MESSAGE.CONFIRM,
+        message: MODAL_MESSAGE.ALERT.FAIL_SUBSCRIBE_NOTI,
+        buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,
         onClose: () => closeModal(modals.alert),
-        routerTo: () => {
-          closeModal(modals.alert);
-          routerToMajorDecision();
-        },
       });
       return;
     }
@@ -126,7 +149,7 @@ const My = () => {
             <span>학과 공지사항 알림받기</span>
             <ToggleButton
               isOn={Boolean(subscribe)}
-              changeState={handleSubscribeTopic}
+              changeState={handleNotiModal}
               animation={animation}
             />
           </CardList>

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -26,6 +26,20 @@ const My = () => {
 
   const routerToMajorDecision = () => routerTo('/major-decision');
 
+  const postSuggestion = async () => {
+    await http.post(
+      `${SERVER_URL}/api/suggestion`,
+      {
+        content: `${major} ${window.navigator.userAgent} 서비스워커 없음`,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  };
+
   const handleSuggestionModal = () => {
     openModal<typeof modals.suggestion>(modals.suggestion, {
       title: MODAL_MESSAGE.SUGGESTION_TITLE,
@@ -80,6 +94,7 @@ const My = () => {
     }
 
     if (!('serviceWorker' in navigator)) {
+      postSuggestion();
       openModal<typeof modals.alert>(modals.alert, {
         message: MODAL_MESSAGE.ALERT.FAIL_SUBSCRIBE_NOTI,
         buttonMessage: MODAL_BUTTON_MESSAGE.CLOSE,


### PR DESCRIPTION
## 🤠 개요

- closes: #245 
- 알림 설정하기 전 모달창을 통해 몇시에 어떤 정보를 전해주는지 알려주도록 추가했어요
- 알림 설정이 실패 시 설정 실패 모달과 함께 노션 건의사항에 전송하도록 추가했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
https://github.com/GDSC-PKNU-21-22/pknu-notice-front/assets/71641127/7f0d8ce2-6ad7-462d-8c77-60566e56e766

