### PR TITLE
Fix: google play console 의 fingerprints 값 추가

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "com.amplifyapp.d1xmrqbiduo1fa.main.twa",
       "sha256_cert_fingerprints": [
-        "BD:F2:0B:71:B1:D4:78:50:E3:1E:92:B0:64:C2:A7:75:5A:6B:74:57:5F:6A:FD:30:94:81:A0:C4:25:19:8A:EF"
+        "BD:F2:0B:71:B1:D4:78:50:E3:1E:92:B0:64:C2:A7:75:5A:6B:74:57:5F:6A:FD:30:94:81:A0:C4:25:19:8A:EF",
+        "48:26:57:71:E3:2E:62:8E:97:B0:F5:95:CF:15:0B:35:DC:48:52:17:5A:67:D1:8E:88:38:42:3B:59:BF:D5:0B"
       ]
     }
   }


### PR DESCRIPTION
## 🤠 개요

- closes: #251 
- 현재 안드로이드의 play store 로 받은 부림이의 경우 chrome 엔진 기반으로 열리면 URL 이 보이는 문제가 있어요
- 그 이유는 TWA 라고 해서 chrome 에서 우리 앱을 제대로 신뢰하지 않기에 그렇다고 해요
- 그래서 https://<YOUR-PWA-URL>/.well-known/assetlinks.json 주소에 TWA 정보를 입력해 둬야해요
- 여기서 추가한 점은 google play console 의 부림이 앱의 설정 -> 앱 서명의 SHA-256 인증서 지문값을 추가해줬어요
- 자세한 사항은 아래에서 확인할 수 있어요

https://docs.pwabuilder.com/#/builder/asset-links-faq?id=removing-the-browser-address-bar
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
